### PR TITLE
Use TinyUSB

### DIFF
--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -16,7 +16,9 @@ board_build.core = earlephilhower
 build_unflags = -D PICO_STDIO_UART
 monitor_speed = 115200
 board_build.f_cpu = 264000000L
-build_flags = -D PICO_NO_FPGA_CHECK=1
+build_flags =
+	-DPICO_NO_FPGA_CHECK=1
+	-DUSE_TINYUSB
 debug_tool = cmsis-dap
 ; upload_protocol = cmsis-dap
 

--- a/Firmware/src/global.h
+++ b/Firmware/src/global.h
@@ -1,8 +1,10 @@
 #define LITTLEFS_BB 0
 #define SD_BB 1
 #define BLACKBOX_STORAGE SD_BB
-#define ENABLE_DEDICATED_SPI 1
 #include "typedefs.h"
+#ifdef USE_TINYUSB
+#include <Adafruit_TinyUSB.h>
+#endif
 #include <Arduino.h>
 
 #if BLACKBOX_STORAGE == LITTLEFS_BB
@@ -44,7 +46,6 @@
 #include "serialhandler/elrs.h"
 #include "serialhandler/gps.h"
 #include "taskManager.h"
-// #include <Adafruit_TinyUSB.h>
 
 #define SPI_GYRO spi0
 #define SPI_OSD spi0


### PR DESCRIPTION
TinyUSB has faster data transfer. This will lead to more possible transfers from the configurator (start page has quite slow attitude updates due to limited message speed), as well as faster blackbox transfers

To test:
- new blackbox transfer speed
- race and buffer/latency conditions on start page (biggest culprit seems to be message speed _to_ the FC, at least with the stock Arduino/Pico SDK stack)