### PR TITLE
Different Blackbox frame types

### DIFF
--- a/Configurator/src/utils/blackbox/bbFlags.ts
+++ b/Configurator/src/utils/blackbox/bbFlags.ts
@@ -54,33 +54,55 @@ const getLatitudeRange = (file: BBLog | undefined) => {
 }
 
 export const BB_ALL_FLAGS: { [key: string]: FlagProps } = {
-	LOG_ROLL_ELRS_RAW: {
-		name: "Roll ELRS Raw",
-		path: "elrsRoll",
+	LOG_ELRS_RAW: {
+		name: "ELRS Raw",
+		path: "",
 		minValue: 988,
 		maxValue: 2012,
 		unit: "µs",
+		modifier: [
+			{
+				displayNameShort: "Roll",
+				displayName: "Roll",
+				path: "elrsRoll",
+			},
+			{
+				displayNameShort: "Pitch",
+				displayName: "Pitch",
+				path: "elrsPitch",
+			},
+			{
+				displayNameShort: "Throttle",
+				displayName: "Throttle",
+				path: "elrsThrottle",
+			},
+			{
+				displayNameShort: "Yaw",
+				displayName: "Yaw",
+				path: "elrsYaw",
+			},
+		],
 	},
-	LOG_PITCH_ELRS_RAW: {
-		name: "Pitch ELRS Raw",
-		path: "elrsPitch",
-		minValue: 988,
-		maxValue: 2012,
-		unit: "µs",
+	LOG_DUMMY_1: {
+		name: "unused",
+		path: "1",
+		minValue: 0,
+		maxValue: 1,
+		unit: "",
 	},
-	LOG_THROTTLE_ELRS_RAW: {
-		name: "Throttle ELRS Raw",
-		path: "elrsThrottle",
-		minValue: 1000,
-		maxValue: 2000,
-		unit: "µs",
+	LOG_DUMMY_2: {
+		name: "unused",
+		path: "2",
+		minValue: 0,
+		maxValue: 1,
+		unit: "",
 	},
-	LOG_YAW_ELRS_RAW: {
-		name: "Yaw ELRS Raw",
-		path: "elrsYaw",
-		minValue: 988,
-		maxValue: 2012,
-		unit: "µs",
+	LOG_DUMMY_3: {
+		name: "unused",
+		path: "3",
+		minValue: 0,
+		maxValue: 1,
+		unit: "",
 	},
 	LOG_ROLL_SETPOINT: {
 		name: "Roll Setpoint",
@@ -250,12 +272,11 @@ export const BB_ALL_FLAGS: { [key: string]: FlagProps } = {
 		maxValue: 1000,
 		unit: "µs",
 	},
-	LOG_FLIGHT_MODE: {
-		name: "Flight Mode",
-		path: "flightMode",
+	LOG_DUMMY_4: {
+		name: "unused",
+		path: "unused",
 		minValue: 0,
-		maxValue: 4,
-		states: ["Acro", "Angle", "Altitude Hold", "GPS Velocity", "GPS Position"],
+		maxValue: 1,
 		unit: "",
 	},
 	LOG_ALTITUDE: {

--- a/Configurator/src/utils/blackbox/parsing.ts
+++ b/Configurator/src/utils/blackbox/parsing.ts
@@ -1,5 +1,5 @@
 import { BBLog, LogData } from "@utils/types"
-import { leBytesToInt } from "@utils/utils"
+import { leBytesToBigInt, leBytesToInt } from "@utils/utils"
 import { BB_ALL_FLAGS } from "@utils/blackbox/bbFlags"
 
 const ACC_RANGES = [2, 4, 8, 16]
@@ -13,8 +13,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		return magic.toString(16)
 	}
 	const version = header.slice(4, 7)
-	const sTime = leBytesToInt(header.slice(7, 11)) // unix timestamp in seconds (UTC)
-	const startTime = new Date(sTime * 1000)
+	const startTime = new Date(leBytesToInt(header.slice(7, 11)) * 1000)
 	const pidFreq = 3200 / (1 + header[11])
 	const freqDiv = header[12]
 	const rangeByte = header[13]
@@ -65,9 +64,6 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 			case 37:
 				frameSize += 6
 				break
-			case 28:
-				frameSize += 1
-				break
 			case 42:
 			case 44:
 			case 45:
@@ -76,53 +72,88 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 			case 43:
 				frameSize += 3
 				break
+			case 0: // ELRS_RAW
+			case 31: // GPS
+				break
+			case 1: // unused
+			case 2: // unused
+			case 3: // unused
+			case 28: // unused
+				break
 			default:
 				frameSize += 2
 				break
 		}
 	}
+	let pos = 0
+	let frameCount = 0
+	let framePos: number[] = []
+	let flightModes: { fm: number; frame: number }[] = []
+	let highlights: number[] = []
+	let gpsPos: { pos: number; frame: number }[] = []
+	let elrsPos: { pos: number; frame: number }[] = []
+	while (pos < data.length) {
+		switch (data[pos]) {
+			case 0: // regular frame
+				framePos[frameCount++] = pos + 1
+				pos += frameSize + 1
+				break
+			case 1: // flight mode
+				flightModes.push({ fm: data[pos + 1], frame: frameCount })
+				pos += 2
+				break
+			case 2: // highlight
+				highlights.push(frameCount)
+				pos += 1
+				break
+			case 3: // GPS
+				gpsPos.push({ pos, frame: frameCount })
+				pos += 93
+				break
+			case 4: // ELRS
+				elrsPos.push({ pos, frame: frameCount })
+				pos += 7
+				break
+			default:
+				pos++
+				break
+		}
+	}
 	const motorPoles = header[142]
 	const framesPerSecond = pidFreq / freqDiv
-	const frames = data.length / frameSize
-	const frameCount = Math.floor(frames)
 	const logData: LogData = {}
-	if (flags.includes("LOG_ROLL_ELRS_RAW")) {
+	if (flags.includes("LOG_ELRS_RAW")) {
 		logData.elrsRoll = new Uint16Array(frameCount)
-		const o = offsets["LOG_ROLL_ELRS_RAW"]
-		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
-			logData.elrsRoll[f] = leBytesToInt(data.slice(p, p + 2))
-		}
-	}
-	if (flags.includes("LOG_PITCH_ELRS_RAW")) {
 		logData.elrsPitch = new Uint16Array(frameCount)
-		const o = offsets["LOG_PITCH_ELRS_RAW"]
-		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
-			logData.elrsPitch[f] = leBytesToInt(data.slice(p, p + 2))
-		}
-	}
-	if (flags.includes("LOG_THROTTLE_ELRS_RAW")) {
 		logData.elrsThrottle = new Uint16Array(frameCount)
-		const o = offsets["LOG_THROTTLE_ELRS_RAW"]
-		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
-			logData.elrsThrottle[f] = leBytesToInt(data.slice(p, p + 2))
-		}
-	}
-	if (flags.includes("LOG_YAW_ELRS_RAW")) {
 		logData.elrsYaw = new Uint16Array(frameCount)
-		const o = offsets["LOG_YAW_ELRS_RAW"]
-		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
-			logData.elrsYaw[f] = leBytesToInt(data.slice(p, p + 2))
+		const a: boolean[] = Array(frameCount).fill(false)
+		for (const e of elrsPos) {
+			let d = leBytesToBigInt(data.slice(e.pos + 1, e.pos + 7), false)
+			const f = e.frame
+			logData.elrsRoll[f] = Number(d & 0xfffn)
+			d >>= 12n
+			logData.elrsPitch[f] = Number(d & 0xfffn)
+			d >>= 12n
+			logData.elrsThrottle[f] = Number(d & 0xfffn)
+			d >>= 12n
+			logData.elrsYaw[f] = Number(d & 0xfffn)
+			a[f] = true
+		}
+		for (let i = 1; i < frameCount; i++) {
+			if (!a[i]) {
+				logData.elrsRoll[i] = logData.elrsRoll[i - 1]
+				logData.elrsPitch[i] = logData.elrsPitch[i - 1]
+				logData.elrsThrottle[i] = logData.elrsThrottle[i - 1]
+				logData.elrsYaw[i] = logData.elrsYaw[i - 1]
+			}
 		}
 	}
 	if (flags.includes("LOG_ROLL_SETPOINT")) {
 		logData.setpointRoll = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_SETPOINT"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.setpointRoll[f] = leBytesToInt(data.slice(p, p + 2), true) / 16 // data is 12.4 fixed point
 		}
 	}
@@ -130,7 +161,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.setpointPitch = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_SETPOINT"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.setpointPitch[f] = leBytesToInt(data.slice(p, p + 2), true) / 16 // data is 12.4 fixed point
 		}
 	}
@@ -138,7 +169,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.setpointThrottle = new Float32Array(frameCount)
 		const o = offsets["LOG_THROTTLE_SETPOINT"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.setpointThrottle[f] = leBytesToInt(data.slice(p, p + 2)) / 32 + 1000 // data is 12.4 fixed point
 		}
 	}
@@ -146,7 +177,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.setpointYaw = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_SETPOINT"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.setpointYaw[f] = leBytesToInt(data.slice(p, p + 2), true) / 16 // data is 12.4 fixed point
 		}
 	}
@@ -154,7 +185,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.gyroRawRoll = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_GYRO_RAW"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.gyroRawRoll[f] = leBytesToInt(data.slice(p, p + 2), true) / 16 // data is 12.4 fixed point
 		}
 	}
@@ -162,7 +193,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.gyroRawPitch = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_GYRO_RAW"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.gyroRawPitch[f] = leBytesToInt(data.slice(p, p + 2), true) / 16 // data is 12.4 fixed point
 		}
 	}
@@ -170,7 +201,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.gyroRawYaw = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_GYRO_RAW"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.gyroRawYaw[f] = leBytesToInt(data.slice(p, p + 2), true) / 16 // data is 12.4 fixed point
 		}
 	}
@@ -178,7 +209,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidRollP = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_PID_P"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidRollP[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -186,7 +217,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidRollI = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_PID_I"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidRollI[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -194,7 +225,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidRollD = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_PID_D"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidRollD[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -202,7 +233,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidRollFF = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_PID_FF"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidRollFF[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -210,7 +241,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidRollS = new Float32Array(frameCount)
 		const o = offsets["LOG_ROLL_PID_S"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidRollS[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -218,7 +249,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidPitchP = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_PID_P"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidPitchP[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -226,7 +257,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidPitchI = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_PID_I"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidPitchI[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -234,7 +265,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidPitchD = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_PID_D"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidPitchD[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -242,7 +273,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidPitchFF = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_PID_FF"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidPitchFF[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -250,7 +281,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidPitchS = new Float32Array(frameCount)
 		const o = offsets["LOG_PITCH_PID_S"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidPitchS[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -258,7 +289,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidYawP = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_PID_P"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidYawP[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -266,7 +297,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidYawI = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_PID_I"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidYawI[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -274,7 +305,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidYawD = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_PID_D"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidYawD[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -282,7 +313,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidYawFF = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_PID_FF"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidYawFF[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -290,7 +321,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pidYawS = new Float32Array(frameCount)
 		const o = offsets["LOG_YAW_PID_S"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pidYawS[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -301,7 +332,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.motorOutFL = new Uint16Array(frameCount)
 		const o = offsets["LOG_MOTOR_OUTPUTS"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			const throttleBytes = data.slice(p, p + 6)
 			const motors01 = leBytesToInt(throttleBytes.slice(0, 3))
 			const motors23 = leBytesToInt(throttleBytes.slice(3, 6))
@@ -317,25 +348,17 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		const o = offsets["LOG_FRAMETIME"]
 		let t = 0
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.frametime[f] = leBytesToInt(data.slice(p, p + 2))
 			t += logData.frametime[f]
 			logData.timestamp[f] = t
-		}
-	}
-	if (flags.includes("LOG_FLIGHT_MODE")) {
-		logData.flightMode = new Uint8Array(frameCount)
-		const o = offsets["LOG_FLIGHT_MODE"]
-		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
-			logData.flightMode[f] = data[p]
 		}
 	}
 	if (flags.includes("LOG_ALTITUDE")) {
 		logData.altitude = new Float32Array(frameCount)
 		const o = offsets["LOG_ALTITUDE"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.altitude[f] = leBytesToInt(data.slice(p, p + 2), true) / 16
 		}
 	}
@@ -343,7 +366,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.vvel = new Float32Array(frameCount)
 		const o = offsets["LOG_VVEL"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.vvel[f] = leBytesToInt(data.slice(p, p + 2), true) / 256
 		}
 	}
@@ -376,83 +399,75 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.gpsPDop = new Float32Array(frameCount)
 		logData.gpsFlags3 = new Uint16Array(frameCount)
 		const gpsData = new Uint8Array(92)
-		const o = offsets["LOG_GPS"]
-		for (let f = 0; f < frameCount; f++) {
-			const dataPos = f * frameSize + o
-			if (frameCount < f + 3) break // 3 init frames
-			if (
-				leBytesToInt(data.slice(dataPos, dataPos + 2)) === 20551 && // if this frame has 'G' * 256 + 'P'
-				leBytesToInt(data.slice(dataPos + frameSize, dataPos + 2 + frameSize)) === 20563 && // if the next frame has 'S' * 256 + 'P'
-				leBytesToInt(data.slice(dataPos + frameSize * 2, dataPos + 2 + frameSize * 2)) === 21590 // if the 2nd next frame has 'V' * 256 + 'T'
-			) {
-				if (frameCount < f + 49) break // 3 init frames + 46 frames of data
-				for (let j = 0; j < 46; j++) {
-					const gpsBytes = data.slice(dataPos + frameSize * (3 + j), dataPos + frameSize * (3 + j) + 2)
-					gpsData.set(gpsBytes, j * 2)
-				}
-				logData.gpsYear[f] = leBytesToInt(gpsData.slice(4, 6))
-				logData.gpsMonth[f] = gpsData[6]
-				logData.gpsDay[f] = gpsData[7]
-				logData.gpsHour[f] = gpsData[8]
-				logData.gpsMinute[f] = gpsData[9]
-				logData.gpsSecond[f] = gpsData[10]
-				logData.gpsTimeValidityFlags[f] = gpsData[11]
-				logData.gpsTAcc[f] = leBytesToInt(gpsData.slice(12, 16))
-				logData.gpsNs[f] = leBytesToInt(gpsData.slice(16, 20), true)
-				logData.gpsFixType[f] = gpsData[20]
-				logData.gpsFlags[f] = gpsData[21]
-				logData.gpsFlags2[f] = gpsData[22]
-				logData.gpsSatCount[f] = gpsData[23]
-				logData.gpsLon[f] = leBytesToInt(gpsData.slice(24, 28), true) / 10000000
-				logData.gpsLat[f] = leBytesToInt(gpsData.slice(28, 32), true) / 10000000
-				logData.gpsAlt[f] = leBytesToInt(gpsData.slice(36, 40), true) / 1000
-				logData.gpsHAcc[f] = leBytesToInt(gpsData.slice(40, 44)) / 1000
-				logData.gpsVAcc[f] = leBytesToInt(gpsData.slice(44, 48)) / 1000
-				logData.gpsVelN[f] = leBytesToInt(gpsData.slice(48, 52), true) / 1000
-				logData.gpsVelE[f] = leBytesToInt(gpsData.slice(52, 56), true) / 1000
-				logData.gpsVelD[f] = leBytesToInt(gpsData.slice(56, 60), true) / 1000
-				logData.gpsGSpeed[f] = leBytesToInt(gpsData.slice(60, 64), true) / 1000
-				logData.gpsHeadMot[f] = leBytesToInt(gpsData.slice(64, 68), true) / 100000
-				logData.gpsSAcc[f] = leBytesToInt(gpsData.slice(68, 72)) / 1000
-				logData.gpsHeadAcc[f] = leBytesToInt(gpsData.slice(72, 76)) / 100000
-				logData.gpsPDop[f] = leBytesToInt(gpsData.slice(76, 78)) / 100
-				logData.gpsFlags3[f] = leBytesToInt(gpsData.slice(78, 80))
-			} else if (f > 0) {
-				logData.gpsYear[f] = logData.gpsYear[f - 1]
-				logData.gpsMonth[f] = logData.gpsMonth[f - 1]
-				logData.gpsDay[f] = logData.gpsDay[f - 1]
-				logData.gpsHour[f] = logData.gpsHour[f - 1]
-				logData.gpsMinute[f] = logData.gpsMinute[f - 1]
-				logData.gpsSecond[f] = logData.gpsSecond[f - 1]
-				logData.gpsTimeValidityFlags[f] = logData.gpsTimeValidityFlags[f - 1]
-				logData.gpsTAcc[f] = logData.gpsTAcc[f - 1]
-				logData.gpsNs[f] = logData.gpsNs[f - 1]
-				logData.gpsFixType[f] = logData.gpsFixType[f - 1]
-				logData.gpsFlags[f] = logData.gpsFlags[f - 1]
-				logData.gpsFlags2[f] = logData.gpsFlags2[f - 1]
-				logData.gpsSatCount[f] = logData.gpsSatCount[f - 1]
-				logData.gpsLon[f] = logData.gpsLon[f - 1]
-				logData.gpsLat[f] = logData.gpsLat[f - 1]
-				logData.gpsAlt[f] = logData.gpsAlt[f - 1]
-				logData.gpsHAcc[f] = logData.gpsHAcc[f - 1]
-				logData.gpsVAcc[f] = logData.gpsVAcc[f - 1]
-				logData.gpsVelN[f] = logData.gpsVelN[f - 1]
-				logData.gpsVelE[f] = logData.gpsVelE[f - 1]
-				logData.gpsVelD[f] = logData.gpsVelD[f - 1]
-				logData.gpsGSpeed[f] = logData.gpsGSpeed[f - 1]
-				logData.gpsHeadMot[f] = logData.gpsHeadMot[f - 1]
-				logData.gpsSAcc[f] = logData.gpsSAcc[f - 1]
-				logData.gpsHeadAcc[f] = logData.gpsHeadAcc[f - 1]
-				logData.gpsPDop[f] = logData.gpsPDop[f - 1]
-				logData.gpsFlags3[f] = logData.gpsFlags3[f - 1]
-			}
+		const exclude: number[] = []
+		for (const g of gpsPos) {
+			gpsData.set(data.slice(g.pos + 1, g.pos + 93), 0)
+			const f = g.frame
+			exclude.push(f)
+			logData.gpsYear[f] = leBytesToInt(gpsData.slice(4, 6))
+			logData.gpsMonth[f] = gpsData[6]
+			logData.gpsDay[f] = gpsData[7]
+			logData.gpsHour[f] = gpsData[8]
+			logData.gpsMinute[f] = gpsData[9]
+			logData.gpsSecond[f] = gpsData[10]
+			logData.gpsTimeValidityFlags[f] = gpsData[11]
+			logData.gpsTAcc[f] = leBytesToInt(gpsData.slice(12, 16))
+			logData.gpsNs[f] = leBytesToInt(gpsData.slice(16, 20), true)
+			logData.gpsFixType[f] = gpsData[20]
+			logData.gpsFlags[f] = gpsData[21]
+			logData.gpsFlags2[f] = gpsData[22]
+			logData.gpsSatCount[f] = gpsData[23]
+			logData.gpsLon[f] = leBytesToInt(gpsData.slice(24, 28), true) / 10000000
+			logData.gpsLat[f] = leBytesToInt(gpsData.slice(28, 32), true) / 10000000
+			logData.gpsAlt[f] = leBytesToInt(gpsData.slice(36, 40), true) / 1000
+			logData.gpsHAcc[f] = leBytesToInt(gpsData.slice(40, 44)) / 1000
+			logData.gpsVAcc[f] = leBytesToInt(gpsData.slice(44, 48)) / 1000
+			logData.gpsVelN[f] = leBytesToInt(gpsData.slice(48, 52), true) / 1000
+			logData.gpsVelE[f] = leBytesToInt(gpsData.slice(52, 56), true) / 1000
+			logData.gpsVelD[f] = leBytesToInt(gpsData.slice(56, 60), true) / 1000
+			logData.gpsGSpeed[f] = leBytesToInt(gpsData.slice(60, 64), true) / 1000
+			logData.gpsHeadMot[f] = leBytesToInt(gpsData.slice(64, 68), true) / 100000
+			logData.gpsSAcc[f] = leBytesToInt(gpsData.slice(68, 72)) / 1000
+			logData.gpsHeadAcc[f] = leBytesToInt(gpsData.slice(72, 76)) / 100000
+			logData.gpsPDop[f] = leBytesToInt(gpsData.slice(76, 78)) / 100
+			logData.gpsFlags3[f] = leBytesToInt(gpsData.slice(78, 80))
+		}
+		for (let i = 1; i < frameCount; i++) {
+			if (exclude.includes(i)) continue
+			logData.gpsYear[i] = logData.gpsYear[i - 1]
+			logData.gpsMonth[i] = logData.gpsMonth[i - 1]
+			logData.gpsDay[i] = logData.gpsDay[i - 1]
+			logData.gpsHour[i] = logData.gpsHour[i - 1]
+			logData.gpsMinute[i] = logData.gpsMinute[i - 1]
+			logData.gpsSecond[i] = logData.gpsSecond[i - 1]
+			logData.gpsTimeValidityFlags[i] = logData.gpsTimeValidityFlags[i - 1]
+			logData.gpsTAcc[i] = logData.gpsTAcc[i - 1]
+			logData.gpsNs[i] = logData.gpsNs[i - 1]
+			logData.gpsFixType[i] = logData.gpsFixType[i - 1]
+			logData.gpsFlags[i] = logData.gpsFlags[i - 1]
+			logData.gpsFlags2[i] = logData.gpsFlags2[i - 1]
+			logData.gpsSatCount[i] = logData.gpsSatCount[i - 1]
+			logData.gpsLon[i] = logData.gpsLon[i - 1]
+			logData.gpsLat[i] = logData.gpsLat[i - 1]
+			logData.gpsAlt[i] = logData.gpsAlt[i - 1]
+			logData.gpsHAcc[i] = logData.gpsHAcc[i - 1]
+			logData.gpsVAcc[i] = logData.gpsVAcc[i - 1]
+			logData.gpsVelN[i] = logData.gpsVelN[i - 1]
+			logData.gpsVelE[i] = logData.gpsVelE[i - 1]
+			logData.gpsVelD[i] = logData.gpsVelD[i - 1]
+			logData.gpsGSpeed[i] = logData.gpsGSpeed[i - 1]
+			logData.gpsHeadMot[i] = logData.gpsHeadMot[i - 1]
+			logData.gpsSAcc[i] = logData.gpsSAcc[i - 1]
+			logData.gpsHeadAcc[i] = logData.gpsHeadAcc[i - 1]
+			logData.gpsPDop[i] = logData.gpsPDop[i - 1]
+			logData.gpsFlags3[i] = logData.gpsFlags3[i - 1]
 		}
 	}
 	if (flags.includes("LOG_ATT_ROLL")) {
 		logData.rollAngle = new Float32Array(frameCount)
 		const o = offsets["LOG_ATT_ROLL"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.rollAngle[f] = ((leBytesToInt(data.slice(p, p + 2), true) / 10000) * 180) / Math.PI
 		}
 	}
@@ -460,7 +475,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.pitchAngle = new Float32Array(frameCount)
 		const o = offsets["LOG_ATT_PITCH"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.pitchAngle[f] = ((leBytesToInt(data.slice(p, p + 2), true) / 10000) * 180) / Math.PI
 		}
 	}
@@ -468,7 +483,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.yawAngle = new Float32Array(frameCount)
 		const o = offsets["LOG_ATT_YAW"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.yawAngle[f] = ((leBytesToInt(data.slice(p, p + 2), true) / 10000) * 180) / Math.PI
 		}
 	}
@@ -479,7 +494,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.rpmFL = new Float32Array(frameCount)
 		const o = offsets["LOG_MOTOR_RPM"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			const motors01 = leBytesToInt(data.slice(p, p + 3))
 			const motors23 = leBytesToInt(data.slice(p + 3, p + 6))
 			let rr = motors01 & 0xfff
@@ -518,7 +533,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.accelRawZ = new Float32Array(frameCount)
 		const o = offsets["LOG_ACCEL_RAW"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.accelRawX[f] = (leBytesToInt(data.slice(p, p + 2), true) * 9.81) / 2048
 			logData.accelRawY[f] = (leBytesToInt(data.slice(p + 2, p + 4), true) * 9.81) / 2048
 			logData.accelRawZ[f] = (leBytesToInt(data.slice(p + 4, p + 6), true) * 9.81) / 2048
@@ -530,7 +545,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.accelFilteredZ = new Float32Array(frameCount)
 		const o = offsets["LOG_ACCEL_FILTERED"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.accelFilteredX[f] = (leBytesToInt(data.slice(p, p + 2), true) * 9.81) / 2048
 			logData.accelFilteredY[f] = (leBytesToInt(data.slice(p + 2, p + 4), true) * 9.81) / 2048
 			logData.accelFilteredZ[f] = (leBytesToInt(data.slice(p + 4, p + 6), true) * 9.81) / 2048
@@ -540,7 +555,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.accelVertical = new Float32Array(frameCount)
 		const o = offsets["LOG_VERTICAL_ACCEL"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.accelVertical[f] = leBytesToInt(data.slice(p, p + 2), true) / 128
 		}
 	}
@@ -548,7 +563,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.setpointVvel = new Float32Array(frameCount)
 		const o = offsets["LOG_VVEL_SETPOINT"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.setpointVvel[f] = leBytesToInt(data.slice(p, p + 2), true) / 4096
 		}
 	}
@@ -556,7 +571,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.magHeading = new Float32Array(frameCount)
 		const o = offsets["LOG_MAG_HEADING"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.magHeading[f] = ((leBytesToInt(data.slice(p, p + 2), true) / 8192) * 180) / Math.PI
 		}
 	}
@@ -564,7 +579,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.combinedHeading = new Float32Array(frameCount)
 		const o = offsets["LOG_COMBINED_HEADING"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.combinedHeading[f] = ((leBytesToInt(data.slice(p, p + 2), true) / 8192) * 180) / Math.PI
 		}
 	}
@@ -573,7 +588,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.hvelE = new Float32Array(frameCount)
 		const o = offsets["LOG_HVEL"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.hvelN[f] = leBytesToInt(data.slice(p, p + 2), true) / 256
 			logData.hvelE[f] = leBytesToInt(data.slice(p + 2, p + 4), true) / 256
 		}
@@ -584,7 +599,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.baroAlt = new Float32Array(frameCount)
 		const o = offsets["LOG_BARO"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.baroRaw[f] = leBytesToInt(data.slice(p, p + 3))
 			logData.baroHpa[f] = logData.baroRaw[f] / 4096
 			logData.baroAlt[f] = 44330 * (1 - Math.pow(logData.baroHpa[f] / 1013.25, 1 / 5.255))
@@ -594,7 +609,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.debug1 = new Int32Array(frameCount)
 		const o = offsets["LOG_DEBUG_1"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.debug1[f] = leBytesToInt(data.slice(p, p + 4), true)
 		}
 	}
@@ -602,7 +617,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.debug2 = new Int32Array(frameCount)
 		const o = offsets["LOG_DEBUG_2"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.debug2[f] = leBytesToInt(data.slice(p, p + 4), true)
 		}
 	}
@@ -610,7 +625,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.debug3 = new Int16Array(frameCount)
 		const o = offsets["LOG_DEBUG_3"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.debug3[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
@@ -618,12 +633,12 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		logData.debug4 = new Int16Array(frameCount)
 		const o = offsets["LOG_DEBUG_4"]
 		for (let f = 0; f < frameCount; f++) {
-			const p = f * frameSize + o
+			const p = framePos[f] + o
 			logData.debug4[f] = leBytesToInt(data.slice(p, p + 2), true)
 		}
 	}
 	return {
-		frameCount: frames,
+		frameCount,
 		flags,
 		logData,
 		version,
@@ -638,5 +653,7 @@ export function parseBlackbox(binFile: Uint8Array): BBLog | string {
 		isExact: true,
 		pidConstantsNice,
 		motorPoles,
-	} as BBLog
+		flightModes,
+		highlights,
+	}
 }

--- a/Configurator/src/utils/types.ts
+++ b/Configurator/src/utils/types.ts
@@ -101,6 +101,8 @@ export type LogData = {
 
 export type BBLog = {
 	frameCount: number
+	flightModes: { fm: number; frame: number }[]
+	highlights: number[]
 	rawFile: Uint8Array
 	flags: string[]
 	logData: LogData

--- a/Configurator/src/utils/utils.ts
+++ b/Configurator/src/utils/utils.ts
@@ -1,10 +1,25 @@
 export const leBytesToInt = (bytes: number[] | Uint8Array, signed = false) => {
 	let value = 0
+	let mul = 1
 	for (let i = 0; i < bytes.length; i++) {
-		value += bytes[i] * Math.pow(256, i)
+		value += bytes[i] * mul
+		mul *= 256
 	}
 	if (signed && bytes[bytes.length - 1] & 0b10000000) {
-		value -= Math.pow(256, bytes.length)
+		value -= mul
+	}
+	return value
+}
+
+export const leBytesToBigInt = (bytes: number[] | Uint8Array, signed = false) => {
+	let value = 0n
+	let mul = 1n
+	for (let i = 0; i < bytes.length; i++) {
+		value += BigInt(bytes[i]) * mul
+		mul *= 256n
+	}
+	if (signed && bytes[bytes.length - 1] & 0b10000000) {
+		value -= mul
 	}
 	return value
 }

--- a/Configurator/src/views/Blackbox.vue
+++ b/Configurator/src/views/Blackbox.vue
@@ -484,7 +484,7 @@ export default defineComponent({
 				}
 				//write down frame number, time in s after start and values next to the cursor at the top
 				let t = (closestFrameNum / this.loadedLog!.framesPerSecond).toFixed(3)
-				if (this.loadedLog!.logData.timestamp) t = (this.loadedLog!.logData.timestamp[closestFrameSliceSkip] / 1e6).toFixed(4)
+				if (this.loadedLog!.logData.timestamp) t = (this.loadedLog!.logData.timestamp[closestFrameNum] / 1e6).toFixed(4)
 				const timeText = t + 's, Frame ' + closestFrameNum;
 				const valueTexts: string[] = [];
 				for (let i = 0; i < numGraphs; i++) {

--- a/Firmware/include/ringbuffer.h
+++ b/Firmware/include/ringbuffer.h
@@ -91,7 +91,7 @@ public:
 		rdPtr = 0;
 		return 0;
 	}
-	/// @brief get the item at index index, does not pop
+	/// @brief get (peek at) the item at index index, does not pop
 	T &operator[](size_t index) {
 		return buffer[(index + rdPtr) % pSize];
 	}

--- a/Firmware/src/blackbox.cpp
+++ b/Firmware/src/blackbox.cpp
@@ -406,9 +406,6 @@ void writeSingleFrame() {
 		bbBuffer[bufferPos++] = ft;
 		bbBuffer[bufferPos++] = ft >> 8;
 	}
-	if (currentBBFlags & LOG_FLIGHT_MODE) {
-		bbBuffer[bufferPos++] = (u8)flightMode;
-	}
 	if (currentBBFlags & LOG_ALTITUDE) {
 		const u32 height = combinedAltitude.raw >> 12; // 12.4 fixed point, approx. 6cm resolution, 4km altitude
 		bbBuffer[bufferPos++] = height;

--- a/Firmware/src/blackbox.h
+++ b/Firmware/src/blackbox.h
@@ -1,12 +1,14 @@
+#pragma once
+
 #include "FS.h"
 #include "elapsedMillis.h"
 #include "serialhandler/msp.h"
 #include "typedefs.h"
 #include <Arduino.h>
-#define LOG_ROLL_ELRS_RAW (1 << 0) // 2 bytes
-#define LOG_PITCH_ELRS_RAW (1 << 1) // 2 bytes
-#define LOG_THROTTLE_ELRS_RAW (1 << 2) // 2 bytes
-#define LOG_YAW_ELRS_RAW (1 << 3) // 2 bytes
+// #define LOG_ROLL_ELRS_RAW (1 << 0) // 2 bytes
+// #define LOG_PITCH_ELRS_RAW (1 << 1) // 2 bytes
+// #define LOG_THROTTLE_ELRS_RAW (1 << 2) // 2 bytes
+// #define LOG_YAW_ELRS_RAW (1 << 3) // 2 bytes
 #define LOG_ROLL_SETPOINT (1 << 4) // 2 bytes
 #define LOG_PITCH_SETPOINT (1 << 5) // 2 bytes
 #define LOG_THROTTLE_SETPOINT (1 << 6) // 2 bytes
@@ -34,10 +36,10 @@
 #define LOG_MOTOR_OUTPUTS (1 << 26) // 6 bytes
 #define LOG_FRAMETIME (1 << 27) // 2 bytes
 // 60 bytes total
-#define LOG_FLIGHT_MODE (1 << 28) // 1 byte
+// #define LOG_FLIGHT_MODE (1 << 28) // 1 byte
 #define LOG_ALTITUDE (1 << 29) // 2 bytes
 #define LOG_VVEL (1 << 30) // 2 bytes
-#define LOG_GPS (1U << 31) // 2 bytes
+// #define LOG_GPS (1U << 31) // 2 bytes
 #define LOG_ATT_ROLL (1LL << 32) // 2 bytes
 #define LOG_ATT_PITCH (1LL << 33) // 2 bytes
 #define LOG_ATT_YAW (1LL << 34) // 2 bytes
@@ -68,6 +70,12 @@
 #define LOG_HEAD_LOGGED_FIELDS 134
 #define LOG_HEAD_MOTOR_POLES 142
 #define LOG_HEAD_LENGTH 256
+
+#define BB_FRAME_NORMAL 0 // normal frame, i.e. gyro, setpoints, pid, etc.
+#define BB_FRAME_FLIGHTMODE 1 // flight mode change
+#define BB_FRAME_HIGHLIGHT 2 // highlight frame, user pressed a button to highlight this frame
+#define BB_FRAME_GPS 3 // GPS frame, i.e. PVT message
+#define BB_FRAME_RC 4 // RC frame, ELRS channels
 
 extern u64 bbFlags; // 64 bits of flags for the blackbox (LOG_ macros)
 extern volatile bool bbLogging, fsReady; // Blackbox state

--- a/Firmware/src/blackbox.h
+++ b/Firmware/src/blackbox.h
@@ -4,10 +4,7 @@
 #include "serialhandler/msp.h"
 #include "typedefs.h"
 #include <Arduino.h>
-// #define LOG_ROLL_ELRS_RAW (1 << 0) // 2 bytes
-// #define LOG_PITCH_ELRS_RAW (1 << 1) // 2 bytes
-// #define LOG_THROTTLE_ELRS_RAW (1 << 2) // 2 bytes
-// #define LOG_YAW_ELRS_RAW (1 << 3) // 2 bytes
+#define LOG_ELRS_RAW (1 << 0) // 6 bytes
 #define LOG_ROLL_SETPOINT (1 << 4) // 2 bytes
 #define LOG_PITCH_SETPOINT (1 << 5) // 2 bytes
 #define LOG_THROTTLE_SETPOINT (1 << 6) // 2 bytes
@@ -35,10 +32,10 @@
 #define LOG_MOTOR_OUTPUTS (1 << 26) // 6 bytes
 #define LOG_FRAMETIME (1 << 27) // 2 bytes
 // 60 bytes total
-// #define LOG_FLIGHT_MODE (1 << 28) // 1 byte
 #define LOG_ALTITUDE (1 << 29) // 2 bytes
+
 #define LOG_VVEL (1 << 30) // 2 bytes
-// #define LOG_GPS (1U << 31) // 2 bytes
+#define LOG_GPS (1U << 31) // 2 bytes
 #define LOG_ATT_ROLL (1LL << 32) // 2 bytes
 #define LOG_ATT_PITCH (1LL << 33) // 2 bytes
 #define LOG_ATT_YAW (1LL << 34) // 2 bytes
@@ -68,6 +65,7 @@
 #define LOG_HEAD_PID_GAINS 74
 #define LOG_HEAD_LOGGED_FIELDS 134
 #define LOG_HEAD_MOTOR_POLES 142
+#define LOG_HEAD_DURATION 143
 #define LOG_HEAD_LENGTH 256
 
 #define BB_FRAME_NORMAL 0 // normal frame, i.e. gyro, setpoints, pid, etc.

--- a/Firmware/src/blackbox.h
+++ b/Firmware/src/blackbox.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "FS.h"
 #include "elapsedMillis.h"
 #include "serialhandler/msp.h"
 #include "typedefs.h"
@@ -82,6 +81,7 @@ extern volatile bool bbLogging, fsReady; // Blackbox state
 extern u8 bbFreqDivider; // Blackbox frequency divider (compared to PID loop)
 extern u32 bbDebug1, bbDebug2;
 extern u16 bbDebug3, bbDebug4;
+extern SdFs sdCard; // SD card filesystem
 
 /// @brief Set up SD card and create /blackbox folder
 void initBlackbox();

--- a/Firmware/src/drivers/speaker.cpp
+++ b/Firmware/src/drivers/speaker.cpp
@@ -54,7 +54,7 @@ RTTTLSong songToPlay;
 #define FREQ_TO_WRAP(freq) (2000000 / freq)
 
 u8 speakerSm, sliceNum;
-File speakerFile;
+FsFile speakerFile;
 u32 speakerDataSize = 0;
 u32 speakerCounter = 0;
 const f32 WAV_SPEAKER_CLKDIV = (float)F_CPU / (256 * 44100 * 4);
@@ -295,7 +295,7 @@ bool playWav(const char *filename) {
 		return false;
 	}
 	if (fsReady) {
-		speakerFile = SDFS.open(filename, "r");
+		speakerFile = sdCard.open(filename);
 		if (speakerFile && speakerFile.size() > 1002) {
 			while (speakerFile.position() < 1000) { // skip wav header
 				if (speakerFile.read() == 'd' && speakerFile.read() == 'a' && speakerFile.read() == 't' && speakerFile.read() == 'a') {

--- a/Firmware/src/drivers/speaker.h
+++ b/Firmware/src/drivers/speaker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <string>
 
 #define MAX_RTTTL_NOTES 256
 #define MAX_RTTTL_TEXT_LENGTH 1024

--- a/Firmware/src/global.h
+++ b/Firmware/src/global.h
@@ -21,7 +21,6 @@
 #include "drivers/speaker.h"
 #include "drivers/spi.h"
 #include "elapsedMillis.h"
-#include "git_version.h"
 #include "imu.h"
 #include "modes.h"
 #include "pid.h"

--- a/Firmware/src/global.h
+++ b/Firmware/src/global.h
@@ -7,7 +7,7 @@
 #include <Arduino.h>
 
 #if BLACKBOX_STORAGE == SD_BB
-#include "SDFS.h"
+#include "SdFat.h"
 #endif
 #include "NeoPixelConnect.h"
 #include "PIO_DShot.h"

--- a/Firmware/src/modes.cpp
+++ b/Firmware/src/modes.cpp
@@ -14,10 +14,10 @@ i32 startPointLat, startPointLon;
 u32 armingDisableFlags = 0;
 
 void modesLoop() {
-	if (ELRS->newPacketFlag & 0x00000001) {
+	if (ELRS->newPacketFlag & (1 << 0)) {
 		elapsedMicros taskTimer = 0;
 		tasks[TASK_MODES].runCounter++;
-		ELRS->newPacketFlag &= 0xFFFFFFFE;
+		ELRS->newPacketFlag &= ~(1 << 0); // clear the flag
 		if (!armed) {
 			if (ELRS->consecutiveArmedCycles == 10)
 				armingDisableFlags &= ~0x01;

--- a/Firmware/src/rtc.cpp
+++ b/Firmware/src/rtc.cpp
@@ -89,6 +89,24 @@ void rtcConvertToTimespec(const struct tm *tm, struct timespec *ts) {
 	ts->tv_nsec = 0; // No nanoseconds in this implementation
 }
 
+void getFsTime(u16 *date, u16 *time, u8 *ms10) {
+	// While Linux expects a UTC timestamp here, officially FAT filesystems (and Windows) use local time
+	struct timespec t;
+	if (!rtcGetTime(&t, true)) {
+		*date = 0;
+		*time = 0;
+		*ms10 = 0;
+		return;
+	}
+	struct tm tm;
+	rtcConvertToTm(&t, &tm);
+
+	*date = FS_DATE(tm.tm_year, tm.tm_mon, tm.tm_mday);
+	*time = FS_TIME(tm.tm_hour, tm.tm_min, tm.tm_sec);
+	// 10ms chunks since the last even second
+	*ms10 = (tm.tm_sec & 1) * 100 + t.tv_nsec / 10'000'000;
+}
+
 time_t rtcGetUnixTimestamp() {
 	timespec t;
 	rtcGetTime(&t);

--- a/Firmware/src/rtc.h
+++ b/Firmware/src/rtc.h
@@ -29,3 +29,5 @@ time_t rtcGetUnixTimestamp();
 time_t rtcGetUnixTimestampWithOffset();
 /// @brief Get the current RTC time as a timespec.
 bool rtcGetTime(struct timespec *t, bool withOffset = false);
+/// @brief Get the current RTC time as a filesystem time (date, time and milliseconds).
+void getFsTime(u16 *date, u16 *time, u8 *ms10);

--- a/Firmware/src/serialhandler/msp.cpp
+++ b/Firmware/src/serialhandler/msp.cpp
@@ -1,3 +1,4 @@
+#include "git_version.h"
 #include "global.h"
 
 #define SIGNATURE_LENGTH 32

--- a/Firmware/src/serialhandler/msp.cpp
+++ b/Firmware/src/serialhandler/msp.cpp
@@ -610,19 +610,17 @@ void processMspCmd(u8 serialNum, MspMsgType mspType, MspFn fn, MspVersion versio
 			 * 0...len-1: file numbers (LE 2 bytes each)
 			 *
 			 * data of response
-			 * 0-1. file number
-			 * 2-5. file size in bytes
-			 * 6-8. version of bb file format
+			 * 0-1: file number
+			 * 2-5: file size in bytes
+			 * 6-8: version of bb file format
 			 * 9-12: time of recording start
-			 * 13. byte that indicates PID frequency
-			 * 14. byte that indicates frequency divider
-			 * 15-22: recording flags
+			 * 13-16: duration in ms
 			 */
 			u8 len = reqLen / 2;
-			len = len > 11 ? 11 : len;
+			len = len > 15 ? 15 : len;
 			u16 fileNums[len];
 			memcpy(fileNums, reqPayload, len * 2);
-			u8 buffer[23 * len];
+			u8 buffer[17 * len];
 			u8 index = 0;
 			for (int i = 0; i < len; i++) {
 				rp2040.wdt_reset();
@@ -642,11 +640,10 @@ void processMspCmd(u8 serialNum, MspMsgType mspType, MspFn fn, MspVersion versio
 				buffer[index++] = (logFile.size() >> 24) & 0xFF;
 				logFile.seek(LOG_HEAD_BB_VERSION);
 				// version, timestamp, pid and divider can directly be read from the file
-				for (int i = 0; i < 9; i++)
+				for (int i = 0; i < 7; i++)
 					buffer[index++] = logFile.read();
-				logFile.seek(LOG_HEAD_LOGGED_FIELDS);
-				// flags
-				for (int i = 0; i < 8; i++)
+				logFile.seek(LOG_HEAD_DURATION);
+				for (int i = 0; i < 4; i++)
 					buffer[index++] = logFile.read();
 				logFile.close();
 			}

--- a/Firmware/src/settings/settingBase.h
+++ b/Firmware/src/settings/settingBase.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "SDFS.h"
+#include "LittleFS.h"
 #include "typedefs.h"
 #include <string>
 


### PR DESCRIPTION
Instead of constant width frames, there are now different frame types available:
- regular frame for e.g. setpoints, PID and motor outputs
- highlight frame: add bookmarks at the push of a button on the remote
- flight mode: no longer a blackbox flag, will always be saved and only when it changes
- ELRS: only when it changes -> reduces space and means lower required bandwidth
- GPS: only when a new packet arrives (and ALWAYS when a new packet arrives). No longer skipped GPS frames, no more wasted space, no more separated GPS frames over several blackbox frames