### PR TITLE
Faster Serial read

### DIFF
--- a/Configurator/src/msp/comm.ts
+++ b/Configurator/src/msp/comm.ts
@@ -430,7 +430,7 @@ function handleRead(rxBuf: number[]) {
 
 const read = () => {
 	if (connectType === "serial" || connectType === "tcp") {
-		invoke(connectType == "serial" ? "serial_read" : "tcp_read")
+		invoke(connectType === "serial" ? "serial_read" : "tcp_read")
 			.then(d => {
 				handleRead(d as number[])
 			})
@@ -497,7 +497,7 @@ export const connect = (portToOpen: string) => {
 			.then(() => {
 				connectType = "serial"
 				cmdEnabled = true
-				readInterval = setInterval(read, 50)
+				readInterval = setInterval(read, 3)
 				pingInterval = setInterval(() => {
 					sendCommand(MspFn.CONFIGURATOR_PING).catch(() => {})
 					pingStarted = Date.now()


### PR DESCRIPTION
At some point I accidentally changed the polling rate on the serial port to 20Hz. This sets it back up to 300Hz. Now we have approx. 3.5MBit/s rather than <1MBit/s when transferring blackbox logs