### PR TITLE
GPL short license in each file

### DIFF
--- a/Configurator/index.html
+++ b/Configurator/index.html
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <!doctype html>
 <html lang="en">
 	<head>

--- a/Configurator/src-tauri/src/lib.rs
+++ b/Configurator/src-tauri/src/lib.rs
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 use serialport::SerialPort;
 use std::collections::HashSet;
 use std::io::{ErrorKind, Read, Write};

--- a/Configurator/src/App.vue
+++ b/Configurator/src/App.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { MspFn } from "@/msp/protocol";

--- a/Configurator/src/components/Channel.vue
+++ b/Configurator/src/components/Channel.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { map, constrain } from "@utils/utils";

--- a/Configurator/src/components/Drone3dPreview.vue
+++ b/Configurator/src/components/Drone3dPreview.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 defineProps<{
 	roll: number,

--- a/Configurator/src/components/Leaflet.vue
+++ b/Configurator/src/components/Leaflet.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <template>
 	<div ref="mapContainer" class="map-wrapper"></div>
 </template>

--- a/Configurator/src/components/Motor.vue
+++ b/Configurator/src/components/Motor.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 

--- a/Configurator/src/components/NumericInput.vue
+++ b/Configurator/src/components/NumericInput.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { mathEval, roundToDecimal } from "@/utils/utils";
 import { defineComponent, PropType } from "vue";

--- a/Configurator/src/components/ReceiverDevice.vue
+++ b/Configurator/src/components/ReceiverDevice.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { onCommandHandler, sendCommand, strToArray } from '@/msp/comm'
 import { MspFn } from '@/msp/protocol'

--- a/Configurator/src/components/RemapMotors.vue
+++ b/Configurator/src/components/RemapMotors.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { onBeforeUnmount, ref } from 'vue'
 import { sendCommand } from '@/msp/comm'

--- a/Configurator/src/components/RxMode.vue
+++ b/Configurator/src/components/RxMode.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 

--- a/Configurator/src/components/SensorGraph.vue
+++ b/Configurator/src/components/SensorGraph.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { MspFn } from "@/msp/protocol";
 import { TRACE_COLORS_FOR_BLACK_BACKGROUND } from "@/utils/constants";

--- a/Configurator/src/components/Tooltip.vue
+++ b/Configurator/src/components/Tooltip.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 defineProps<{
 	position: 'bottom' | 'top' | 'left' | 'right' | 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'

--- a/Configurator/src/components/blackbox/Settings.vue
+++ b/Configurator/src/components/blackbox/Settings.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { sendCommand } from '@/msp/comm';
 import { MspFn } from '@/msp/protocol';

--- a/Configurator/src/components/blackbox/Timeline.vue
+++ b/Configurator/src/components/blackbox/Timeline.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 import { GenFlagProps, FlagProps, BBLog, TypedArray } from "@utils/types";

--- a/Configurator/src/components/blackbox/TracePlacer.vue
+++ b/Configurator/src/components/blackbox/TracePlacer.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { BBLog, FlagProps, GenFlagProps, TypedArray, TraceInGraph, TraceInternalData } from '@utils/types';
 import { defineComponent, PropType } from 'vue';

--- a/Configurator/src/components/hardwarePorts/adc.vue
+++ b/Configurator/src/components/hardwarePorts/adc.vue
@@ -1,0 +1,19 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+

--- a/Configurator/src/components/hardwarePorts/addPort.vue
+++ b/Configurator/src/components/hardwarePorts/addPort.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { useLogStore } from '@/stores/logStore';
 import { usePortStore } from '@/stores/portStore';

--- a/Configurator/src/components/hardwarePorts/analogOsd.vue
+++ b/Configurator/src/components/hardwarePorts/analogOsd.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { onBeforeUnmount } from 'vue';
 

--- a/Configurator/src/components/hardwarePorts/dshot.vue
+++ b/Configurator/src/components/hardwarePorts/dshot.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { sendCommand } from '@/msp/comm';
 import { MspFn } from '@/msp/protocol';

--- a/Configurator/src/components/hardwarePorts/i2c.vue
+++ b/Configurator/src/components/hardwarePorts/i2c.vue
@@ -1,0 +1,19 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+

--- a/Configurator/src/components/hardwarePorts/imu.vue
+++ b/Configurator/src/components/hardwarePorts/imu.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { sendCommand } from '@/msp/comm'
 import { MspFn } from '@/msp/protocol'

--- a/Configurator/src/components/hardwarePorts/largeFs.vue
+++ b/Configurator/src/components/hardwarePorts/largeFs.vue
@@ -1,0 +1,19 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+

--- a/Configurator/src/components/hardwarePorts/ledstrip.vue
+++ b/Configurator/src/components/hardwarePorts/ledstrip.vue
@@ -1,0 +1,19 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+

--- a/Configurator/src/components/hardwarePorts/serial.vue
+++ b/Configurator/src/components/hardwarePorts/serial.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { onConnectHandler, onDisconnectHandler, sendCommand } from '@/msp/comm';
 import { MspFn } from '@/msp/protocol';

--- a/Configurator/src/components/hardwarePorts/speaker.vue
+++ b/Configurator/src/components/hardwarePorts/speaker.vue
@@ -1,0 +1,19 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+

--- a/Configurator/src/msp/comm.ts
+++ b/Configurator/src/msp/comm.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { invoke } from "@tauri-apps/api/core"
 import { MspFn, MspVersion } from "@/msp/protocol"
 import { Command } from "@utils/types"

--- a/Configurator/src/msp/protocol.ts
+++ b/Configurator/src/msp/protocol.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export const MspFn = {
 	API_VERSION: 1,
 	FIRMWARE_VARIANT: 2,

--- a/Configurator/src/router.ts
+++ b/Configurator/src/router.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { createRouter, createWebHistory } from "vue-router"
 import Home from "@views/Home.vue"
 import Blackbox from "@views/Blackbox.vue"

--- a/Configurator/src/stores/logStore.ts
+++ b/Configurator/src/stores/logStore.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { defineStore } from "pinia"
 import { ref } from "vue"
 

--- a/Configurator/src/stores/portStore.ts
+++ b/Configurator/src/stores/portStore.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { defineStore } from "pinia"
 import { computed, ref } from "vue"
 

--- a/Configurator/src/utils/blackbox/bbFlags.ts
+++ b/Configurator/src/utils/blackbox/bbFlags.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { BBLog, GenFlagProps, FlagProps } from "../types"
 
 const getGyroBBRange = (file: BBLog | undefined) => {

--- a/Configurator/src/utils/blackbox/flagGen.ts
+++ b/Configurator/src/utils/blackbox/flagGen.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { BBLog } from "@utils/types"
 import { BB_GEN_FLAGS } from "@utils/blackbox/bbFlags"
 import { PT1 } from "@utils/filters"

--- a/Configurator/src/utils/blackbox/other.ts
+++ b/Configurator/src/utils/blackbox/other.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { BBLog, LogData, TypedArray } from "@utils/types"
 import { bigIntToLeBytes, intToLeBytes, uint8ArrayEquals } from "../utils"
 import { escapeBlackbox } from "./parsing"

--- a/Configurator/src/utils/blackbox/parsing.ts
+++ b/Configurator/src/utils/blackbox/parsing.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { BBLog, LogData, TypedArray } from "@utils/types"
 import { leBytesToBigInt, leBytesToInt } from "@utils/utils"
 import { BB_ALL_FLAGS } from "@utils/blackbox/bbFlags"

--- a/Configurator/src/utils/blackbox/saveView.ts
+++ b/Configurator/src/utils/blackbox/saveView.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { BBLog, TraceInGraph, TraceInternalData } from "@/utils/types"
 
 let cachedLog: BBLog | undefined

--- a/Configurator/src/utils/constants.ts
+++ b/Configurator/src/utils/constants.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export const TRACE_COLORS_FOR_BLACK_BACKGROUND = [
 	"red",
 	"lime",

--- a/Configurator/src/utils/filters.ts
+++ b/Configurator/src/utils/filters.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export class PT1 {
 	cutoffFreq: number
 	sampleFreq: number

--- a/Configurator/src/utils/fonts.ts
+++ b/Configurator/src/utils/fonts.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export default {
 	betaflight:`MAX7456
 01010101

--- a/Configurator/src/utils/types.ts
+++ b/Configurator/src/utils/types.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export type TypedArray =
 	| Int8Array
 	| Uint8Array

--- a/Configurator/src/utils/utils.ts
+++ b/Configurator/src/utils/utils.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import Mexp from "math-expression-evaluator"
 import { ActualCoeffs } from "./types"
 

--- a/Configurator/src/utils/worker/sensorCanvas.ts
+++ b/Configurator/src/utils/worker/sensorCanvas.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // worker thread to draw a single sensor canvas
 let canvas: HTMLCanvasElement
 const MAX_WIDTH = 600 // max frame count

--- a/Configurator/src/views/Battery.vue
+++ b/Configurator/src/views/Battery.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import NumericInput from "@/components/NumericInput.vue";
 import { onConnectHandler, sendCommand } from "@/msp/comm";

--- a/Configurator/src/views/Blackbox.vue
+++ b/Configurator/src/views/Blackbox.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent, toRaw } from "vue";
 import Timeline from "@components/blackbox/Timeline.vue";

--- a/Configurator/src/views/Cli.vue
+++ b/Configurator/src/views/Cli.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { onCommandHandler, onConnectHandler, sendCommand } from "@/msp/comm";
 import { MspFn } from "@/msp/protocol";

--- a/Configurator/src/views/GpsMag.vue
+++ b/Configurator/src/views/GpsMag.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { sendCommand, onCommandHandler } from "@/msp/comm";

--- a/Configurator/src/views/HardwareSetup.vue
+++ b/Configurator/src/views/HardwareSetup.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import Drone3dPreview from '@components/Drone3dPreview.vue';
 import Imu from '@components/hardwarePorts/imu.vue'

--- a/Configurator/src/views/Home.vue
+++ b/Configurator/src/views/Home.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { onCommandHandler, getPingTime, sendCommand, sendRaw, disconnect, enableCommands } from '@/msp/comm';

--- a/Configurator/src/views/Motors.vue
+++ b/Configurator/src/views/Motors.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import Motor from "@components/Motor.vue";
 import { defineComponent } from "vue";

--- a/Configurator/src/views/Osd.vue
+++ b/Configurator/src/views/Osd.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { sendCommand } from "@/msp/comm";
 import { MspFn } from "@/msp/protocol";

--- a/Configurator/src/views/Receiver.vue
+++ b/Configurator/src/views/Receiver.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import Channel from "@components/Channel.vue";
 import { defineComponent } from "vue";

--- a/Configurator/src/views/Sensors.vue
+++ b/Configurator/src/views/Sensors.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { sendCommand, onCommandHandler } from "@/msp/comm";

--- a/Configurator/src/views/Tasks.vue
+++ b/Configurator/src/views/Tasks.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { sendCommand, } from "@/msp/comm";

--- a/Configurator/src/views/Tuning.vue
+++ b/Configurator/src/views/Tuning.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script lang="ts">
 import { defineComponent } from "vue";
 import { MspFn } from "@/msp/protocol";

--- a/Configurator/src/views/Vtx.vue
+++ b/Configurator/src/views/Vtx.vue
@@ -1,3 +1,22 @@
+<!--
+ + Copyright (c) 2026 Kolibri-FC contributors
+ + 
+ + This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ + 
+ + Kolibri-FC is free software: you can redistribute it and/or modify
+ + it under the terms of the GNU General Public License as published by
+ + the Free Software Foundation, either version 3 of the License, or
+ + (at your option) any later version.
+ + 
+ + Kolibri-FC is distributed in the hope that it will be useful,
+ + but WITHOUT ANY WARRANTY; without even the implied warranty of
+ + MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ + GNU General Public License for more details.
+ + 
+ + You should have received a copy of the GNU General Public License
+ + along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+-->
+
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { onConnectHandler, sendCommand } from '@/msp/comm'

--- a/Firmware/include/customSimdMath.h
+++ b/Firmware/include/customSimdMath.h
@@ -1,3 +1,25 @@
+/**
+ * @file customSimdMath.h
+ * @brief Functions to speed up some math operations using ARM SIMD instructions. Only used on Cortex-M4 and M7 targets.
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "arm_acle.h"
 
 #if __ARM_FEATURE_SIMD32

--- a/Firmware/include/pioasm/extended_spi.pio
+++ b/Firmware/include/pioasm/extended_spi.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .program extended_spi
 .side_set 1 opt
 

--- a/Firmware/include/pioasm/halfduplex_spi.pio
+++ b/Firmware/include/pioasm/halfduplex_spi.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .program halfduplex_spi_11
 .side_set 1 opt
 

--- a/Firmware/include/pioasm/halfduplex_uart.pio
+++ b/Firmware/include/pioasm/halfduplex_uart.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 ; Halfduplex UART (Onewire Serial)
 ; operates at 23 clock ticks per bit
 ; automatically switches to TX when data is present in the TX FIFO

--- a/Firmware/include/pioasm/onewire_receive.pio
+++ b/Firmware/include/pioasm/onewire_receive.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .program onewire_receive
 
 ; a small delay here tends to reduce transmission errors if the pullup is missing

--- a/Firmware/include/pioasm/onewire_transmit.pio
+++ b/Firmware/include/pioasm/onewire_transmit.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .program onewire_transmit
 
 ; a small delay here tends to reduce transmission errors if the pullup is missing

--- a/Firmware/include/pioasm/uart_rx.pio
+++ b/Firmware/include/pioasm/uart_rx.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 ; Normal UART RX (e.g. 8N1)
 ; operates at 32 ticks per bit
 

--- a/Firmware/include/pioasm/uart_tx.pio
+++ b/Firmware/include/pioasm/uart_tx.pio
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2026 Kolibri-FC contributors
+ * 
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ * 
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 ; Normal UART TX (e.g. 8N1)
 ; operates at 32 ticks per bit
 ; requires extensive configuration and packet prep:

--- a/Firmware/include/ringbuffer.h
+++ b/Firmware/include/ringbuffer.h
@@ -1,3 +1,25 @@
+/**
+ * @file ringbuffer.h
+ * @brief Generic ring buffer template implementation, mostly used for buffering IO data.
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 template <typename T>
 class RingBuffer {

--- a/Firmware/include/targets.h
+++ b/Firmware/include/targets.h
@@ -1,3 +1,25 @@
+/**
+ * @file targets.h
+ * @brief Pinouts for targets, as well as some other target-specific definitions.
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #define SD_BB 0

--- a/Firmware/include/typedefs.h
+++ b/Firmware/include/typedefs.h
@@ -1,3 +1,25 @@
+/**
+ * @file typedefs.h
+ * @brief Rust-style type definitions for fixed-width integers and floating-point numbers, to improve code readability.
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 // Rust just has better names for these types
 

--- a/Firmware/python/gitVersion.py
+++ b/Firmware/python/gitVersion.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2026 Kolibri-FC contributors
+# 
+# This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+# 
+# Kolibri-FC is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Kolibri-FC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+
 Import("env")
 import subprocess
 from pathlib import Path

--- a/Firmware/src/adc.cpp
+++ b/Firmware/src/adc.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file adc.cpp
+ * @brief ADC reading and battery management implementation
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 u16 adcVoltage = 0, cellVoltage = 0; // centivolts

--- a/Firmware/src/adc.h
+++ b/Firmware/src/adc.h
@@ -1,3 +1,25 @@
+/**
+ * @file adc.h
+ * @brief Header file for ADC reading and battery management implementation
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "typedefs.h"
 extern u16 adcVoltage;
 extern f32 adcCurrent;

--- a/Firmware/src/blackbox.cpp
+++ b/Firmware/src/blackbox.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file blackbox.cpp
+ * @brief Implementation of the blackbox logging system (write to SD/flash and read to configurator)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 #ifdef BLACKBOX_STORAGE

--- a/Firmware/src/blackbox.h
+++ b/Firmware/src/blackbox.h
@@ -1,3 +1,25 @@
+/**
+ * @file blackbox.h
+ * @brief Interface declaration for blackbox logging
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "drivers/flashBb.h"

--- a/Firmware/src/control.cpp
+++ b/Firmware/src/control.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file control.cpp
+ * @brief Implementation of different flight modes (acro, angle etc.) => generate setpoints for the PID controller based on the flight mode and the pilot's stick input
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static fix32 angleModeP = 5;

--- a/Firmware/src/control.h
+++ b/Firmware/src/control.h
@@ -1,3 +1,25 @@
+/**
+ * @file control.h
+ * @brief Interface declaration for control functions => generate setpoints for the PID controller based on the flight mode and the pilot's stick input
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 enum class FlightMode {

--- a/Firmware/src/drivers/baro.cpp
+++ b/Firmware/src/drivers/baro.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file baro.cpp
+ * @brief Barometer driver implementation (currently SPL006 or LPS22, depending on the target)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 #include <math.h>
 

--- a/Firmware/src/drivers/baro.h
+++ b/Firmware/src/drivers/baro.h
@@ -1,3 +1,25 @@
+/**
+ * @file baro.h
+ * @brief Barometer driver interface (currently SPL006 or LPS22, depending on the target)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include <Arduino.h>
 #include <fixedPointInt.h>

--- a/Firmware/src/drivers/esc.cpp
+++ b/Firmware/src/drivers/esc.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file esc.cpp
+ * @brief ESC management implementation (control, remapping, ...), using the pico-bidir-dshot library.
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static u32 enableDShot = 0;

--- a/Firmware/src/drivers/esc.h
+++ b/Firmware/src/drivers/esc.h
@@ -1,3 +1,25 @@
+/**
+ * @file esc.h
+ * @brief ESC management interface (control, remapping, ...), using the pico-bidir-dshot library.
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "PIO_DShot.h"
 #include <Arduino.h>

--- a/Firmware/src/drivers/flashBb.cpp
+++ b/Firmware/src/drivers/flashBb.cpp
@@ -1,4 +1,24 @@
-
+/**
+ * @file flashBb.cpp
+ * @brief Implementation of Fckafd and FlashBbFile, filesystem and file, for the flash chip
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "global.h"
 #include "pioasm/extended_spi.pio.h"

--- a/Firmware/src/drivers/flashBb.h
+++ b/Firmware/src/drivers/flashBb.h
@@ -1,3 +1,25 @@
+/**
+ * @file flashBb.h
+ * @brief Fckafd and FlashBbFile class definitions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #if BLACKBOX_STORAGE == FLASH_BB
 

--- a/Firmware/src/drivers/gyro.cpp
+++ b/Firmware/src/drivers/gyro.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file gyro.cpp
+ * @brief Gyroscope driver and calibration implementation (BMI270 and ICM42688P)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 // driver for the BMI270 IMU https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf

--- a/Firmware/src/drivers/gyro.h
+++ b/Firmware/src/drivers/gyro.h
@@ -1,3 +1,25 @@
+/**
+ * @file gyro.h
+ * @brief Gyroscope driver and calibration interface (BMI270 and ICM42688P)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <Arduino.h>

--- a/Firmware/src/drivers/halfduplexUart.cpp
+++ b/Firmware/src/drivers/halfduplexUart.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file halfduplexUart.cpp
+ * @brief Partial implementation of SerialPioHdx class, a pio-based half-duplex UART implentation
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static u8 programOffsets[NUM_PIOS];

--- a/Firmware/src/drivers/halfduplexUart.h
+++ b/Firmware/src/drivers/halfduplexUart.h
@@ -1,3 +1,25 @@
+/**
+ * @file halfduplexUart.h
+ * @brief Interface and partial implementation of SerialPioHdx class, a pio-based half-duplex UART implentation
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "Arduino.h"
 #include "typedefs.h"

--- a/Firmware/src/drivers/i2c.cpp
+++ b/Firmware/src/drivers/i2c.cpp
@@ -1,3 +1,24 @@
+/**
+ * @file i2c.cpp
+ * @brief Functions for asynchronous I2C communication
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "Wire.h"
 #include "global.h"

--- a/Firmware/src/drivers/i2c.h
+++ b/Firmware/src/drivers/i2c.h
@@ -1,3 +1,25 @@
+/**
+ * @file i2c.h
+ * @brief Functions for asynchronous I2C communication
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 extern u8 i2c0blocker;

--- a/Firmware/src/drivers/mag.cpp
+++ b/Firmware/src/drivers/mag.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file mag.cpp
+ * @brief Magnetometer driver implementation (HMC5883L, QMC5883L)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 // on drone: x = right, y = backward, z = down

--- a/Firmware/src/drivers/mag.h
+++ b/Firmware/src/drivers/mag.h
@@ -1,3 +1,25 @@
+/**
+ * @file mag.h
+ * @brief Magnetometer interface (HMC5883L, QMC5883L)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "targets.h"
 #include "typedefs.h"
 

--- a/Firmware/src/drivers/osd.cpp
+++ b/Firmware/src/drivers/osd.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file osd.cpp
+ * @brief To be deleted
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 u8 osdReady = false;

--- a/Firmware/src/drivers/osd.h
+++ b/Firmware/src/drivers/osd.h
@@ -1,3 +1,25 @@
+/**
+ * @file osd.h
+ * @brief To be deleted
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <Arduino.h>
 
 enum class OSDReg : u8 {

--- a/Firmware/src/drivers/pioUart.cpp
+++ b/Firmware/src/drivers/pioUart.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file pioUart.cpp
+ * @brief PIO-based UART implementation
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static u8 programOffsetsRx[NUM_PIOS];

--- a/Firmware/src/drivers/pioUart.h
+++ b/Firmware/src/drivers/pioUart.h
@@ -1,3 +1,25 @@
+/**
+ * @file pioUart.h
+ * @brief PIO-based UART class definition
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "Arduino.h"
 #include "typedefs.h"

--- a/Firmware/src/drivers/speaker.cpp
+++ b/Firmware/src/drivers/speaker.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file speaker.cpp
+ * @brief Functions for controlling the speaker
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static elapsedMillis soundStart;

--- a/Firmware/src/drivers/speaker.h
+++ b/Firmware/src/drivers/speaker.h
@@ -1,3 +1,25 @@
+/**
+ * @file speaker.h
+ * @brief Function declarations for controlling the speaker
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <Arduino.h>

--- a/Firmware/src/drivers/spi.cpp
+++ b/Firmware/src/drivers/spi.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file spi.cpp
+ * @brief SPI helper functions for synchronous read/write operations (setup)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 #define READ_BASE 0x000 // used to indicate to the PIO that this byte is a read

--- a/Firmware/src/drivers/spi.h
+++ b/Firmware/src/drivers/spi.h
@@ -1,3 +1,25 @@
+/**
+ * @file spi.h
+ * @brief SPI helper function declarations for synchronous read/write operations (setup)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "hardware/spi.h"
 #include <Arduino.h>
 

--- a/Firmware/src/global.cpp
+++ b/Firmware/src/global.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file global.cpp
+ * @brief Global variables and helper functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 std::optional<ExpressLRS> elrs;

--- a/Firmware/src/global.h
+++ b/Firmware/src/global.h
@@ -1,3 +1,25 @@
+/**
+ * @file global.h
+ * @brief Global includes, defines, variables and helper functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 // general C/C++ includes

--- a/Firmware/src/imu.cpp
+++ b/Firmware/src/imu.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file imu.cpp
+ * @brief Implementation of IMU reading and sensor fusion (complementary filter of gyro and accel, based on quaternions)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 // Partly taken from

--- a/Firmware/src/imu.h
+++ b/Firmware/src/imu.h
@@ -1,3 +1,25 @@
+/**
+ * @file imu.h
+ * @brief Interface with the IMU (gyro and accel) and sensor fusion implementation
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "utils/filters.h"
 #include "utils/quaternion.h"
 #include <Arduino.h>

--- a/Firmware/src/inFlightTuning.cpp
+++ b/Firmware/src/inFlightTuning.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file inFlightTuning.cpp
+ * @brief Implementation of in-flight tuning (TunableParameter class and related functions)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 std::list<TunableParameter> inFlightTuningParams;

--- a/Firmware/src/inFlightTuning.h
+++ b/Firmware/src/inFlightTuning.h
@@ -1,3 +1,25 @@
+/**
+ * @file inFlightTuning.h
+ * @brief TunableParameter class and related functions for in-flight tuning
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 #include <fixedPointInt.h>

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file main.cpp
+ * @brief Main entry point for the Kolibri-FC firmware, initializes hardware and starts the main control loop
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 #include "hardware/structs/qmi.h"
 #include "hardware/vreg.h"

--- a/Firmware/src/modes.cpp
+++ b/Firmware/src/modes.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file modes.cpp
+ * @brief Implementation of flight mode management and RX switches (RxMode class)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 volatile bool armed = false;
 fix64 homepointLat, homepointLon;

--- a/Firmware/src/modes.h
+++ b/Firmware/src/modes.h
@@ -1,3 +1,25 @@
+/**
+ * @file modes.h
+ * @brief Interface declaration for flight mode management and RX switches (RxMode class)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "serialhandler/msp.h"

--- a/Firmware/src/pid.cpp
+++ b/Firmware/src/pid.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file pid.cpp
+ * @brief PID controller implementation for rate control (acro), and idle output
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 /*

--- a/Firmware/src/pid.h
+++ b/Firmware/src/pid.h
@@ -1,3 +1,25 @@
+/**
+ * @file pid.h
+ * @brief Interface declaration for PID controller functions and variables
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include <Arduino.h>
 #include <fixedPointInt.h>

--- a/Firmware/src/pins.cpp
+++ b/Firmware/src/pins.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file pins.cpp
+ * @brief Functions to check pin capabilities
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 bool pinIsAllowed(u8 pin) {

--- a/Firmware/src/pins.h
+++ b/Firmware/src/pins.h
@@ -1,3 +1,25 @@
+/**
+ * @file pins.h
+ * @brief Functions to check pin capabilities
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 

--- a/Firmware/src/rtc.cpp
+++ b/Firmware/src/rtc.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file rtc.cpp
+ * @brief RTC initialization and timekeeping functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 #include <pico/aon_timer.h>
 

--- a/Firmware/src/rtc.h
+++ b/Firmware/src/rtc.h
@@ -1,3 +1,25 @@
+/**
+ * @file rtc.h
+ * @brief Interface for RTC initialization and timekeeping functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "typedefs.h"
 #include <pico/aon_timer.h>
 

--- a/Firmware/src/serial.cpp
+++ b/Firmware/src/serial.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file serial.cpp
+ * @brief Serial management and data polling (round-robin)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 u32 crcLutD5[256] = {};

--- a/Firmware/src/serial.h
+++ b/Firmware/src/serial.h
@@ -1,3 +1,25 @@
+/**
+ * @file serial.h
+ * @brief Serial functions, variables and constants
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "utils/koliSerial.h"

--- a/Firmware/src/serialhandler/4way.cpp
+++ b/Firmware/src/serialhandler/4way.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file 4way.cpp
+ * @brief Implementation of the 4-way interface for flashing and configuring ESCs
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 #include "pioasm/onewire_receive.pio.h"
 #include "pioasm/onewire_transmit.pio.h"

--- a/Firmware/src/serialhandler/4way.h
+++ b/Firmware/src/serialhandler/4way.h
@@ -1,3 +1,25 @@
+/**
+ * @file 4way.h
+ * @brief Function declarations for 4-way interface
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 #include <Arduino.h>

--- a/Firmware/src/serialhandler/cli/clear_et_al.cpp
+++ b/Firmware/src/serialhandler/cli/clear_et_al.cpp
@@ -1,6 +1,28 @@
+/**
+ * @file clear_et_al.cpp
+ * @brief Implementation of the clear, screen and exit commands
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
-void initClear(){
+void initClear() {
 	Command *cmd = new Command("clear", "Clear the screen");
 	cmd->addAlias("cls");
 	cmd->setExecuteFunction([](std::map<string, RuntimeArg> &args, Command *cmd) {
@@ -10,7 +32,7 @@ void initClear(){
 	Command::cliCommands.push_back(cmd);
 }
 
-void initScreen(){
+void initScreen() {
 	Command *cmd = new Command("screen", "Start a new shell session (clears the screen), returning to the previous session on exit");
 	cmd->setExecuteFunction([](std::map<string, RuntimeArg> &args, Command *cmd) {
 		cmd->print("\x0f"); // SI character starts a new session in our terminal emulator
@@ -19,7 +41,7 @@ void initScreen(){
 	Command::cliCommands.push_back(cmd);
 }
 
-void initExit(){
+void initExit() {
 	Command *cmd = new Command("exit", "Exit the current shell session, returning to the previous session if screen command was used");
 	cmd->addAlias("quit");
 	cmd->setExecuteFunction([](std::map<string, RuntimeArg> &args, Command *cmd) {

--- a/Firmware/src/serialhandler/cli/cli.cpp
+++ b/Firmware/src/serialhandler/cli/cli.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file cli.cpp
+ * @brief General CLI functions, and partial implementation of Command class
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 std::vector<Command *> Command::cliCommands;

--- a/Firmware/src/serialhandler/cli/cli.h
+++ b/Firmware/src/serialhandler/cli/cli.h
@@ -1,3 +1,25 @@
+/**
+ * @file cli.h
+ * @brief CLI Command class definition
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "Arduino.h"
 #include "typedefs.h"
 #include <variant>

--- a/Firmware/src/serialhandler/cli/echo.cpp
+++ b/Firmware/src/serialhandler/cli/echo.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file echo.cpp
+ * @brief Implementation of the echo command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 void initEcho() {

--- a/Firmware/src/serialhandler/cli/get.cpp
+++ b/Firmware/src/serialhandler/cli/get.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file get.cpp
+ * @brief Implementation of the get command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 bool vectorHasString(const std::vector<string> &vec, const string &str) {

--- a/Firmware/src/serialhandler/cli/gyro_calibration.cpp
+++ b/Firmware/src/serialhandler/cli/gyro_calibration.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file gyro_calibration.cpp
+ * @brief Implementation of the gyro_calibration command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 static std::vector<SelectionOption> options = {{"start", "Start the gyro calibration"}, {"get", "Print the current gyro calibration data"}};
 static elapsedMicros commandTimer = 0;

--- a/Firmware/src/serialhandler/cli/help.cpp
+++ b/Firmware/src/serialhandler/cli/help.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file help.cpp
+ * @brief Implementation of the help command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 void initHelp() {

--- a/Firmware/src/serialhandler/cli/man.cpp
+++ b/Firmware/src/serialhandler/cli/man.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file man.cpp
+ * @brief Implementation of the man command (actual printing happens in cli.cpp)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static Command cmd("man", "Print manual/documentation for a command");

--- a/Firmware/src/serialhandler/cli/print.cpp
+++ b/Firmware/src/serialhandler/cli/print.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file print.cpp
+ * @brief Implementation of the print command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 void initPrint() {

--- a/Firmware/src/serialhandler/cli/reboot.cpp
+++ b/Firmware/src/serialhandler/cli/reboot.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file reboot.cpp
+ * @brief Implementation of the reboot command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static std::vector<SelectionOption> options = {{"fc", "Reboot normally"}, {"bootloader", "Reboot to bootloader"}};

--- a/Firmware/src/serialhandler/cli/reset.cpp
+++ b/Firmware/src/serialhandler/cli/reset.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file reset.cpp
+ * @brief Implementation of the reset command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 void initReset() {

--- a/Firmware/src/serialhandler/cli/save.cpp
+++ b/Firmware/src/serialhandler/cli/save.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file save.cpp
+ * @brief Implementation of the save command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 void initSave() {

--- a/Firmware/src/serialhandler/cli/serial_stats.cpp
+++ b/Firmware/src/serialhandler/cli/serial_stats.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file serial_stats.cpp
+ * @brief Implementation of the serial_stats command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 void initSerialStats() {

--- a/Firmware/src/serialhandler/cli/set.cpp
+++ b/Firmware/src/serialhandler/cli/set.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file set.cpp
+ * @brief Implementation of the set command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 static std::vector<SelectionOption> options;

--- a/Firmware/src/serialhandler/cli/status.cpp
+++ b/Firmware/src/serialhandler/cli/status.cpp
@@ -1,6 +1,28 @@
+/**
+ * @file status.cpp
+ * @brief Implementation of the status command
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
-void initStatus(){
+void initStatus() {
 	Command *cmd = new Command("status", "Get current status information about the FC");
 	cmd->setExecuteFunction([](std::map<string, RuntimeArg> &args, Command *cmd) {
 		string response = "Firmware: " FIRMWARE_NAME " " FIRMWARE_VERSION_STRING "\n";

--- a/Firmware/src/serialhandler/elrs.cpp
+++ b/Firmware/src/serialhandler/elrs.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file elrs.cpp
+ * @brief ExpressLRS serial parser, handler and connection maintenance functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 #include "hardware/interp.h"
 

--- a/Firmware/src/serialhandler/elrs.h
+++ b/Firmware/src/serialhandler/elrs.h
@@ -1,3 +1,25 @@
+/**
+ * @file elrs.h
+ * @brief ExpressLRS class definition
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "hardware/interp.h"
 #include "msp.h"

--- a/Firmware/src/serialhandler/gps.cpp
+++ b/Firmware/src/serialhandler/gps.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file gps.cpp
+ * @brief GPS (UBX) serial parser functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 RingBuffer<u8> gpsBuffer(1024);

--- a/Firmware/src/serialhandler/gps.h
+++ b/Firmware/src/serialhandler/gps.h
@@ -1,3 +1,25 @@
+/**
+ * @file gps.h
+ * @brief GPS (UBX) serial parser function declarations and related variables
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <Arduino.h>
 #include <pico/aon_timer.h>
 

--- a/Firmware/src/serialhandler/msp.cpp
+++ b/Firmware/src/serialhandler/msp.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file msp.cpp
+ * @brief MSP parsing and handler functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "git_version.h"
 #include "global.h"
 

--- a/Firmware/src/serialhandler/msp.h
+++ b/Firmware/src/serialhandler/msp.h
@@ -1,4 +1,26 @@
 /**
+ * @file msp.h
+ * @brief MSP command list, other enums, parsing and handler function declarations
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
  * MSP Guidelines, emphasis is used to clarify.
  *
  * Each FlightController (FC, Server) MUST change the API version when any MSP command is added, deleted, or changed.

--- a/Firmware/src/serialhandler/tramp.cpp
+++ b/Firmware/src/serialhandler/tramp.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file tramp.cpp
+ * @brief Tramp VTX handler functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 RingBuffer<u8> trampRxBuffer(32);

--- a/Firmware/src/serialhandler/tramp.h
+++ b/Firmware/src/serialhandler/tramp.h
@@ -1,3 +1,25 @@
+/**
+ * @file tramp.h
+ * @brief Interface for Tramp VTX handler functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "Arduino.h"
 #include "drivers/halfduplexUart.h"
 #include "ringbuffer.h"

--- a/Firmware/src/settings/arraySetting.h
+++ b/Firmware/src/settings/arraySetting.h
@@ -1,3 +1,25 @@
+/**
+ * @file arraySetting.h
+ * @brief Implementation of ArraySetting class, which represents a setting that is an array of values (e.g. motor pins).
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "settings/settingBase.h"
 

--- a/Firmware/src/settings/littleFs.cpp
+++ b/Firmware/src/settings/littleFs.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file littleFs.cpp
+ * @brief LittleFS management functions for settings storage on flash chip
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 bool littleFsReady = false;

--- a/Firmware/src/settings/littleFs.h
+++ b/Firmware/src/settings/littleFs.h
@@ -1,3 +1,25 @@
+/**
+ * @file littleFs.h
+ * @brief Header file for LittleFS management functions for settings storage on flash chip
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <Arduino.h>
 #include <LittleFS.h>
 

--- a/Firmware/src/settings/setting.h
+++ b/Firmware/src/settings/setting.h
@@ -1,3 +1,25 @@
+/**
+ * @file setting.h
+ * @brief Template implementations of the Setting class for different data types
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "settings/settingBase.h"
 #include <stdexcept>

--- a/Firmware/src/settings/settingBase.cpp
+++ b/Firmware/src/settings/settingBase.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file settingBase.cpp
+ * @brief Base class for settings, containing common functions for all settings and the settings file management functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 bool SettingBase::getValueString(string &s, const char *id) {

--- a/Firmware/src/settings/settingBase.h
+++ b/Firmware/src/settings/settingBase.h
@@ -1,3 +1,25 @@
+/**
+ * @file settingBase.h
+ * @brief Base class for settings, containing common functions for all settings and the settings file management functions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 #include <LittleFS.h>

--- a/Firmware/src/settings/settingIds.h
+++ b/Firmware/src/settings/settingIds.h
@@ -1,3 +1,25 @@
+/**
+ * @file settingIds.h
+ * @brief Central database of all setting IDs used in Kolibri-FC
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // accelerometer settings
 #define SETTING_ACC_CAL "accel_calibration"
 #define SETTING_ACC_FILTER_CUTOFF "accel_filter_cutoff"

--- a/Firmware/src/taskManager.cpp
+++ b/Firmware/src/taskManager.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file taskManager.cpp
+ * @brief Task manager implementation for tracking task execution times and frequencies
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 __attribute__((__aligned__(4))) volatile FCTask tasks[TASK_LENGTH];
 

--- a/Firmware/src/taskManager.h
+++ b/Firmware/src/taskManager.h
@@ -1,3 +1,25 @@
+/**
+ * @file taskManager.h
+ * @brief Task manager functions, timekeeping shorthands and variables
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "typedefs.h"
 #include <Arduino.h>
 

--- a/Firmware/src/unittest.cpp
+++ b/Firmware/src/unittest.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file unittest.cpp
+ * @brief Unit tests for various components of the Kolibri-FC firmware
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "unittest.h"
 #include "ringbuffer.h"
 #include <fixedPointInt.h>

--- a/Firmware/src/unittest.h
+++ b/Firmware/src/unittest.h
@@ -1,3 +1,25 @@
+/**
+ * @file unittest.h
+ * @brief Unit test class definitions
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 #include <Arduino.h>

--- a/Firmware/src/utils/filters.cpp
+++ b/Firmware/src/utils/filters.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file filters.cpp
+ * @brief Partial implementation of various filters used in Kolibri-FC, e.g. PT1, PT2, ...
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "filters.h"
 #include <cmath>
 

--- a/Firmware/src/utils/filters.h
+++ b/Firmware/src/utils/filters.h
@@ -1,3 +1,25 @@
+/**
+ * @file filters.h
+ * @brief Filter class defintions and partial implementation (PT1, PT2, ...)
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "typedefs.h"
 #include <fixedPointInt.h>

--- a/Firmware/src/utils/koliSerial.cpp
+++ b/Firmware/src/utils/koliSerial.cpp
@@ -1,3 +1,25 @@
+/**
+ * @file koliSerial.cpp
+ * @brief Partial implementation of KoliSerial
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "global.h"
 
 char KoliSerial::serialTypeNames[4][8] = {

--- a/Firmware/src/utils/koliSerial.h
+++ b/Firmware/src/utils/koliSerial.h
@@ -1,3 +1,25 @@
+/**
+ * @file koliSerial.h
+ * @brief KoliSerial class definition, a wrapper for different serial interfaces (USB, UART, PIO, PIO HDx) used for identical interface regardless of the underlying hardware
+ *
+ * Copyright (c) 2026 Kolibri-FC contributors
+ *
+ * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
+ *
+ * Kolibri-FC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kolibri-FC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "drivers/halfduplexUart.h"
 #include "elapsedMillis.h"


### PR DESCRIPTION
According to the GPL license, the following text should be prepended to each source file. I wrote a little script that did this for me and I also added short doxygen @file and @brief to each C++ file in case it ever becomes relevant.