### PR TITLE
Fix live loading

### DIFF
--- a/Configurator/src/components/blackbox/Settings.vue
+++ b/Configurator/src/components/blackbox/Settings.vue
@@ -75,7 +75,7 @@ export default defineComponent({
 				bytes[byte] |= 1 << bit;
 			}
 
-			sendCommand(MspFn.SET_BB_SETTINGS, [this.divider, ...bytes])
+			sendCommand(MspFn.SET_BB_SETTINGS, [this.divider, ...bytes, this.syncFreq])
 				.then(() => { return sendCommand(MspFn.SAVE_SETTINGS) })
 				.then(() => { return this.$emit('close') })
 				.catch(() => {

--- a/Configurator/src/components/hardwarePorts/addPort.vue
+++ b/Configurator/src/components/hardwarePorts/addPort.vue
@@ -101,10 +101,8 @@ function addPort2() {
 				return false
 			return ports.addSerial('pio', txPin.value, rxPin.value)
 		case 'pio-hdx':
-			console.log(1)
 			if (!pioPins.value.includes(hdxPin.value))
 				return false
-			console.log(2)
 			return ports.addSerial('pio-hdx', hdxPin.value, hdxPin.value)
 		default:
 			break;

--- a/Configurator/src/utils/blackbox/parsing.ts
+++ b/Configurator/src/utils/blackbox/parsing.ts
@@ -85,6 +85,7 @@ export function parseBlackboxHeader(header: Uint8Array): BBLog | string {
 		frameCount: 0,
 		usedFastDownload: false,
 		frameLoadingStatus: new Uint8Array(0),
+		possibleFrameTypes: 1,
 		frameSize: 0,
 		framesPerSecond: 0,
 		frequencyDivider: 0,
@@ -151,6 +152,11 @@ export function parseBlackboxHeader(header: Uint8Array): BBLog | string {
 	})
 
 	const flags = bbLog.flags
+
+	if (flags.includes("LOG_ELRS_RAW")) bbLog.possibleFrameTypes |= 0b00010
+	if (flags.includes("LOG_GPS")) bbLog.possibleFrameTypes |= 0b00100
+	if (flags.includes("LOG_VBAT")) bbLog.possibleFrameTypes |= 0b01000
+	if (flags.includes("LOG_LINK_STATS")) bbLog.possibleFrameTypes |= 0b10000
 
 	bbLog.motorPoles = header[150]
 	bbLog.disarmReason = header[151]

--- a/Configurator/src/utils/types.ts
+++ b/Configurator/src/utils/types.ts
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2026 Kolibri-FC contributors
- * 
+ *
  * This file is part of Kolibri-FC (https://github.com/bastian2001/Kolibri-FC).
- * 
+ *
  * Kolibri-FC is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Kolibri-FC is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Kolibri-FC. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -146,6 +146,7 @@ export type BBLog = {
 	syncs: { frame: number; pos: number; ctrlByte: number }[]
 	syncFrequency: number
 	frameLoadingStatus: Uint8Array
+	possibleFrameTypes: number
 	fileSize: number
 	highlights: number[]
 	rawFile?: Uint8Array

--- a/Configurator/src/views/Blackbox.vue
+++ b/Configurator/src/views/Blackbox.vue
@@ -497,10 +497,6 @@ export default defineComponent({
 						res.length === 288
 				})
 
-				if (leBytesToInt(c.data, 0, 2) !== logNum) {
-					this.configuratorLog.push("got invalid response when asking for log")
-					return
-				}
 				const header = c.data.slice(32)
 				const meta = c.data.slice(0, 32)
 				const fileSize = leBytesToInt(meta, 3, 4)

--- a/Configurator/src/views/Blackbox.vue
+++ b/Configurator/src/views/Blackbox.vue
@@ -137,6 +137,13 @@ export default defineComponent({
 						this.handleFileChunk(command.data);
 						break;
 				}
+			} else if (command.cmdType === 'error') {
+				switch (command.command) {
+					case MspFn.BB_FAST_DATA_REQ:
+						if (this.stopFetchingFrames) this.stopFetchingFrames()
+						this.configuratorLog.push('Failed to download file: ' + command.dataStr);
+						break;
+				}
 			}
 		},
 		getFileList() {
@@ -344,7 +351,7 @@ export default defineComponent({
 			let resSize = 2
 			for (; i < maxReqCount; i++) {
 				const fr = frames[i]
-				const fl = 0x1F ^ log.frameLoadingStatus[fr]
+				const fl = (0x1F ^ log.frameLoadingStatus[fr]) & log.possibleFrameTypes
 				const resFrameLength =
 					((fl & 0b00001) ? log.frameSize : 0) +
 					((fl & 0b00010) ? 14 : 0) +
@@ -372,7 +379,7 @@ export default defineComponent({
 			for (; i < reqCount; i++) {
 				const pos = 5 + i * 9
 				const fr = frames[i]
-				const fl = 0x1F ^ log.frameLoadingStatus[fr]
+				const fl = (0x1F ^ log.frameLoadingStatus[fr]) & log.possibleFrameTypes
 
 				reqData.set(intToLeBytes(fr, 4), pos)
 				reqData[pos + 4] = fl
@@ -664,10 +671,7 @@ export default defineComponent({
 			}
 
 			const spawnFetcherInstance = async () => {
-				while (true) {
-					if (stop) {
-						return
-					}
+				while (!stop) {
 					if (!this.loadedLog) {
 						await delay(20)
 						continue

--- a/Configurator/src/views/HardwareSetup.vue
+++ b/Configurator/src/views/HardwareSetup.vue
@@ -218,7 +218,6 @@ function update() {
 		data.push(ser.mspDp.type | (ser.mspDp.resolution << 4))
 		data.push(...Array(9).fill(0)) // reserved
 	})
-	console.log(data)
 	sendCommand(MspFn.SET_SERIAL_SETUP, data)
 		.then((c): Promise<any> => {
 			if (c.data[0]) {

--- a/Configurator/src/views/Osd.vue
+++ b/Configurator/src/views/Osd.vue
@@ -316,7 +316,6 @@ function dragStart(index: number, event: DragEvent, type: 'copy' | 'move', grabb
 	dragTrashHover.value = false;
 }
 function dragEnd(event: DragEvent) {
-	console.log('end')
 	event.preventDefault();
 	dragging.value = 'none'
 }
@@ -357,7 +356,6 @@ function dragoverTrash(event: DragEvent) {
 }
 function dropTrash(event: DragEvent) {
 	event.preventDefault();
-	console.log('drop')
 	delete activeElements.value[draggingIndex.value];
 	collapse();
 	draggingIndex.value = -1;

--- a/Firmware/src/blackbox.cpp
+++ b/Firmware/src/blackbox.cpp
@@ -907,6 +907,7 @@ void printFastDataReq(KoliSerial &serial, MspVersion mspVer, u16 sequenceNum, u1
 		u32 framePos = 0;
 		bool searchingBackwards = true;
 		u32 frameNum = 0;
+		bool seekedToStart = false;
 		memset(frameBuffer, 0, frameSize);
 
 		/*
@@ -926,8 +927,12 @@ void printFastDataReq(KoliSerial &serial, MspVersion mspVer, u16 sequenceNum, u1
 			if (nextSyncPos == 0xFFFFFFFFUL)
 				return sendMsp(s, "Error 1 while reading file", strlen("Error 1 while reading file"));
 			if (nextSyncPos == 0) {
+				if (seekedToStart) {
+					return sendMsp(s, "Error 0 while reading file", strlen("Error 0 while reading file"));
+				}
 				nextSyncPos = 256;
 				frameNum = 0;
+				seekedToStart = true;
 			}
 			file.seek(nextSyncPos);
 			nextSyncPos = 0xFFFFFFFFUL;

--- a/Firmware/src/drivers/flashBb.cpp
+++ b/Firmware/src/drivers/flashBb.cpp
@@ -160,7 +160,7 @@ void Fckafd::invalidateCaches() {
 }
 
 u16 Fckafd::getData(u16 block, u8 page, u16 start, u16 length, u8 *buf) {
-	if ((u32)start + (u32)length > 2176) return 0;
+	if ((u32)start + (u32)length > 2176 || length == 0) return 0;
 	// TODO caching
 	// if (start < 2048) {
 	// 	u8 needSecs = 0b0000;
@@ -196,7 +196,7 @@ void Fckafd::pageRead(u16 block, u8 page, bool getFeatureWait) {
 }
 
 u16 Fckafd::readFromCache(u16 block, u16 start, u16 length, u8 *buf) {
-	if ((u32)start + (u32)length > 2176) return 0;
+	if ((u32)start + (u32)length > 2176 || length == 0) return 0;
 	start |= (block & 0b1) << 12;
 	const u16 lenBackup = length;
 	gpio_put(PIN_FLASH_CS, false);
@@ -585,9 +585,11 @@ bool FlashFile::seek(u32 newPos) {
 		privateFlush();
 	}
 
-	currentBlock = firstBlock + newPos / (fck->pageCount * fck->pageSize);
-	currentPage = (newPos % (fck->pageCount * fck->pageSize)) / fck->pageSize;
-	currentPagePos = newPos % fck->pageSize;
+	const size_t blockSize = fck->pageSize * fck->pageCount;
+	currentBlock = firstBlock + newPos / blockSize;
+	const size_t blockOffset = newPos % blockSize;
+	currentPage = blockOffset / fck->pageSize;
+	currentPagePos = blockOffset % fck->pageSize;
 	currentFilePos = newPos;
 	return true;
 }
@@ -629,37 +631,31 @@ i32 FlashFile::read(u8 *buffer, size_t length) {
 	const u32 startFPos = currentFilePos;
 
 	// simplest read: no page boundary
-	if (currentPagePos + length <= 2048) {
+	if (currentPagePos + length <= fck->pageSize) {
 		fck->getData(currentBlock, currentPage, currentPagePos, length, buffer);
-		for (auto &cb : corrBytes) {
-			if (cb.pos >= startFPos && cb.pos < endExcl) {
-				buffer[cb.pos - startFPos] = cb.byte;
-			}
-		}
 		moveCursorFwd(length);
-		return length;
-	}
-
-	// else read first (part) page
-	u16 thisLength = 2048 - currentPagePos;
-	size_t bufPos = 0;
-	fck->getData(currentBlock, currentPage, currentPagePos, thisLength, buffer);
-	bufPos += thisLength;
-	moveCursorFwd(thisLength);
-
-	// as long as we can still read full pages
-	thisLength = fck->pageSize;
-	while (bufPos + thisLength < length) {
-		fck->getData(currentBlock, currentPage, 0, thisLength, buffer + bufPos);
+	} else {
+		// else read first (part) page
+		size_t thisLength = fck->pageSize - currentPagePos;
+		size_t bufPos = 0;
+		fck->getData(currentBlock, currentPage, currentPagePos, thisLength, buffer);
 		bufPos += thisLength;
 		moveCursorFwd(thisLength);
-	}
 
-	// read remaining bytes
-	thisLength = length - bufPos;
-	fck->getData(currentBlock, currentPage, 0, thisLength, buffer + bufPos);
-	bufPos += thisLength;
-	moveCursorFwd(thisLength);
+		// as long as we can still read full pages
+		thisLength = fck->pageSize;
+		while (length - bufPos > fck->pageSize) {
+			fck->getData(currentBlock, currentPage, 0, thisLength, buffer + bufPos);
+			bufPos += thisLength;
+			moveCursorFwd(thisLength);
+		}
+
+		// read remaining bytes
+		thisLength = length - bufPos;
+		fck->getData(currentBlock, currentPage, 0, thisLength, buffer + bufPos);
+		// bufPos += thisLength;
+		moveCursorFwd(thisLength);
+	}
 
 	for (auto &cb : corrBytes) {
 		if (cb.pos >= startFPos && cb.pos < endExcl) {

--- a/Firmware/src/drivers/flashBb.cpp
+++ b/Firmware/src/drivers/flashBb.cpp
@@ -430,9 +430,7 @@ bool Fckafd::exists(u16 num) {
 }
 
 FlashFile Fckafd::open(u16 num, oflag_t oflag) {
-	printfIndMessage("Open %d", num);
 	if (!fsReady) return FlashFile();
-	printIndMessage("FS ready");
 	if (oflag == O_RDONLY) {
 		return FlashFile(0, num, false, *this);
 	}
@@ -559,7 +557,6 @@ FlashFile::FlashFile(u8 partition, u16 fileNum, bool forWrite, Fckafd &fs) : fck
 						fileSize = DECODE_U4(&buf[3]);
 						foundFile = true;
 						fck->getData(0, page, offset + 512 + 126, 130, buf);
-						printfIndMessage("Opening file %d for read on page %d with offset %d. First block %d, last block %d, total file size %d. Start time %d", fileNum, page, offset, firstBlock, lastBlock, fileSize, startTime);
 						for (int i = 0; i < 26; i++) {
 							int pos = i * 5;
 							u32 bytePos = DECODE_U4(&buf[pos]);

--- a/Firmware/src/drivers/flashBb.h
+++ b/Firmware/src/drivers/flashBb.h
@@ -84,7 +84,7 @@ private:
 	u8 currentPage = 0;
 	u8 writeBuf[512];
 	u32 currentFilePos = 0;
-	u16 currentPagePos = 0;
+	size_t currentPagePos = 0;
 
 	u8 metaPage = 0xFF;
 	u8 metaPagePart = 0;

--- a/Firmware/src/serialhandler/msp.cpp
+++ b/Firmware/src/serialhandler/msp.cpp
@@ -865,6 +865,7 @@ void processMspCmd(KoliSerial &serial, MspMsgType type, MspFn fn, MspVersion ver
 			openSettingsFile();
 			getSetting(SETTING_BB_DIV)->updateSettingInFile();
 			getSetting(SETTING_BB_FLAGS)->updateSettingInFile();
+			getSetting(SETTING_BB_SYNC)->updateSettingInFile();
 #else
 			msgSetup.type = MspMsgType::ERROR;
 			sendMsp(msgSetup);


### PR DESCRIPTION
Loading a blackbox with the live option sometimes failed. I crushed two bugs:
- Sync frequency was set to 0 whenever you updated the blackbox flags, it was unintentionally not sent nor saved
- The special frames, i.e. GPS, ELRS..., were always requested, even when they were not recorded. There is now a catch on the FC side that sends an error in these cases, and the configurator is now smart enough to prevent requesting it in the first place