### PR TITLE
ELRS channel mutex

### DIFF
--- a/Firmware/src/control.cpp
+++ b/Firmware/src/control.cpp
@@ -116,7 +116,13 @@ static fix32 stickThr; // 0...1024
 
 static void inline getStickPos() {
 	fix32 smoothChannels[4]; // smoothed RC channel values (1000ish to 2000ish)
+	bool entered = mutex_try_enter(&elrs->channelMutex, nullptr);
+	if (!entered) entered = mutex_enter_timeout_us(&elrs->channelMutex, 20);
+	// if we did not get the mutex, we can still compute the values, worst case there is some jitter on this frame, but this is a much lower problem than blocking for too long and causing a delayed reaction to the pilot's input
 	elrs->getSmoothChannels(smoothChannels);
+	if (entered) {
+		mutex_exit(&elrs->channelMutex);
+	}
 
 	stickPos[0] = (smoothChannels[0] - 1500) >> 9;
 	stickPos[1] = (smoothChannels[1] - 1500) >> 9;

--- a/Firmware/src/serialhandler/elrs.cpp
+++ b/Firmware/src/serialhandler/elrs.cpp
@@ -110,6 +110,7 @@ struct __attribute__((packed)) crsf_channels_13 {
 
 RingBuffer<u8> elrsBuffer(ELRS_BUFFER_SIZE);
 interp_config ExpressLRS::interpConfig0, ExpressLRS::interpConfig1, ExpressLRS::interpConfig2;
+mutex_t ExpressLRS::channelMutex;
 
 ExpressLRS::ExpressLRS(KoliSerial *serial)
 	: serial(serial) {
@@ -119,6 +120,8 @@ ExpressLRS::ExpressLRS(KoliSerial *serial)
 	interpConfig2 = interp_default_config();
 	interp_config_set_clamp(&interpConfig2, 1);
 	frequencyTimer = 1000000;
+	if (!mutex_is_initialized(&channelMutex))
+		mutex_init(&channelMutex);
 }
 
 void ExpressLRS::loop() {
@@ -311,11 +314,16 @@ void ExpressLRS::processMessage() {
 		for (int i = 0; i < 4; i++) {
 			smooth2[i] = smooth[i].geti32();
 		}
-		memcpy(lastChannels, smooth2, 4 * sizeof(u32));
-		memcpy(&lastChannels[4], &channels[4], 12 * sizeof(u32));
-		sinceLastRCMessage = 0;
-		memcpy(channels, pChannels, 16 * sizeof(u32));
-		newPacketFlag = 0xFFFFFFFF;
+		bool entered = mutex_try_enter(&channelMutex, nullptr);
+		if (!entered) entered = mutex_enter_timeout_us(&channelMutex, 100);
+		if (entered) {
+			memcpy(lastChannels, smooth2, 4 * sizeof(u32));
+			memcpy(&lastChannels[4], &channels[4], 12 * sizeof(u32));
+			sinceLastRCMessage = 0;
+			memcpy(channels, pChannels, 16 * sizeof(u32));
+			mutex_exit(&channelMutex);
+			newPacketFlag = 0xFFFFFFFF;
+		}
 		rcPacketRateCounter++;
 		rcMsgCount++;
 	} break;
@@ -441,11 +449,16 @@ void ExpressLRS::processMessage() {
 		for (int i = 0; i < 4; i++) {
 			smooth2[i] = smooth[i].geti32();
 		}
-		memcpy(lastChannels, smooth2, 4 * sizeof(u32));
-		memcpy(&lastChannels[4], &channels[4], 12 * sizeof(u32));
-		sinceLastRCMessage = 0;
-		memcpy(channels, pChannels, 16 * sizeof(u32));
-		newPacketFlag = 0xFFFFFFFF;
+		bool entered = mutex_try_enter(&channelMutex, nullptr);
+		if (!entered) entered = mutex_enter_timeout_us(&channelMutex, 100);
+		if (entered) {
+			memcpy(lastChannels, smooth2, 4 * sizeof(u32));
+			memcpy(&lastChannels[4], &channels[4], 12 * sizeof(u32));
+			sinceLastRCMessage = 0;
+			memcpy(channels, pChannels, 16 * sizeof(u32));
+			mutex_exit(&channelMutex);
+			newPacketFlag = 0xFFFFFFFF;
+		}
 		rcPacketRateCounter++;
 		rcMsgCount++;
 	} break;

--- a/Firmware/src/serialhandler/elrs.h
+++ b/Firmware/src/serialhandler/elrs.h
@@ -66,6 +66,7 @@ public:
 	u32 lastChannels[16] = {}; // RC channels from the last packet (1000-2000 for switches, 988-2012 for other sticks)
 	u32 newPacketFlag = 0; // flags for new RC packets (set to 0xFFFFFFFF when a new packet is received)
 	u32 newLinkStatsFlag = 0; // flags for new link stats (set to 0xFFFFFFFF when a new link stats are available)
+	static mutex_t channelMutex; // core 0 reserves for writing, core 1 for reading, to prevent incorrect smoothing
 
 	// custom link info
 	elapsedMicros sinceLastRCMessage; // time (µs) since the last valid RC message was received


### PR DESCRIPTION
Prevents (or rather tries to prevent – there are timeouts) rare glitches (caused by race condition) on the smoothed channels